### PR TITLE
Fix SQS provider to use queues that don't match attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nyc_output
 coverage
 node_modules
+npm-debug.log

--- a/lib/providers/sqs.js
+++ b/lib/providers/sqs.js
@@ -80,6 +80,19 @@ SqsProvider.prototype._deleteMessage = function(receiptHandle) {
 
 SqsProvider.prototype._initProvider = function() {
   var self = this;
+  var param = { QueueName: self._q };
+
+  self._sqs.getQueueUrl(param, function(err, data) {
+    if (err) {
+      return self._createQueue(err);
+    }
+
+    self._setQueueReady(data.QueueUrl);
+  });
+};
+
+SqsProvider.prototype._createQueue = function(getQueueUrlError) {
+  var self = this;
 
   var param = {
     QueueName: self._q,
@@ -88,15 +101,20 @@ SqsProvider.prototype._initProvider = function() {
 
   self._sqs.createQueue(param, function(err, data) {
     if (err) {
+      self.emitter.emit('error', getQueueUrlError);
       self.emitter.emit('error', err);
       return;
     }
 
-    self._queueUrl = data.QueueUrl;
-
-    self.emitter.isReady = true;
-    self.emitter.emit('ready');
+    self._setQueueReady(data.QueueUrl);
   });
+};
+
+SqsProvider.prototype._setQueueReady = function(queueUrl) {
+  this._queueUrl = queueUrl;
+
+  this.emitter.isReady = true;
+  this.emitter.emit('ready');
 };
 
 SqsProvider.prototype._poll = function(done) {


### PR DESCRIPTION
Addresses issue #15.  Previously the SQS provider could not be initialized if referencing a queue that existed, but didn't match the attributes exactly.  This fix allows queues that exist but don't match attributes to be used.  It does this by first attempting a `getQueueUrl` call, then if that causes an error, uses the `createUrl` method to create.  If they both fail, both errors will be emitted.