### PR TITLE
Add coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "0.10"
   - "4"
   - "6"
+script: npm run cover

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 common-mq is an abstracted message queue client package for Node.js with a clean, common API for working with
 various message queue providers.
 
-[![Build Status](https://travis-ci.org/lloydcotten/common-mq.svg?branch=master)](https://travis-ci.org/lloydcotten/common-mq)
+[![Build Status](https://travis-ci.org/lloydcotten/common-mq.svg?branch=master)](https://travis-ci.org/lloydcotten/common-mq) [![Coverage Status](https://coveralls.io/repos/github/lloydcotten/common-mq/badge.svg)](https://coveralls.io/github/lloydcotten/common-mq)
 
 ## Provider Support
 


### PR DESCRIPTION
`node-tap` has built-in support for generating the lcov info and piping it to the coveralls commands and Travis sends it off to coveralls.  This simply changes the default test command used to use the `npm run cover` command instead.