### PR TITLE
Update dependencies for the v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes:
 - Add unit tests
 - Integrate with TravisCI, AppVeyor, and Coveralls
 - Change ZeroMQ dependency to use better supported library with prebuilt binaries
+- AWS config credentials can be set from your environment using recommended practices
 
 Bug Fixes:
 - AMQP provider implementation should work in more situations now

--- a/README.md
+++ b/README.md
@@ -39,13 +39,7 @@ var queue = mq.connect('sqs://todos', {
     ReceiveMessageWaitTimeSeconds: '20'
   },
 
-  // AWS config
-  awsConfig: {
-    accessKeyId: 'ACCESS_KEY_HERE',
-    secretAccessKey: 'SECRET_KEY_HERE',
-    region: 'us-east-1'
-    maxRetries: 10
-  }
+  awsConfig: { region: 'us-east-1' }
 
 });
 
@@ -207,7 +201,7 @@ Required options:
 
 * provider `string` (when not using connection URL)
 * queueName `string` (when not using connection URL)
-* awsConfig `object|string` AWS config options to pass to the [`update` method](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#update-property), otherwise a path to AWS config file to pass to the [`loadFromPath` method](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#loadFromPath-property)
+* awsConfig `object|string` AWS config options to pass to the [`update` method](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#update-property), otherwise a path to AWS config file to pass to the [`loadFromPath` method](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#loadFromPath-property) - see [AWS Developer Guide](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/configuring-the-jssdk.html) for more information
 
 Other options:
 

--- a/examples/sqs.simple.js
+++ b/examples/sqs.simple.js
@@ -11,11 +11,9 @@ var queue = mq.connect('sqs://hello', {
     ReceiveMessageWaitTimeSeconds: '2'
   },
 
-  // AWS config
-  // Replace with your AWS access id and secrety access key
+  // For mopre information on this configuration see:
+  // http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/configuring-the-jssdk.html
   awsConfig: {
-    accessKeyId: 'AWS_ACCESS_KEY_ID',
-    secretAccessKey: 'AWS_SECRET_ACCESS_KEY',
     region: 'us-east-1',
     maxRetries: 10
   }
@@ -36,6 +34,8 @@ queue.on('message', printMessage);
 
 queue.on('error', function(err) {
   console.log(err);
+  console.log('Do you need to setup your environment with your AWS credentials?');
+  console.log('http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html');
 });
 
 function printMessage(message) {

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   "author": "Lloyd Cotten",
   "license": "MIT",
   "dependencies": {
-    "async": "~0.2",
-    "aws-sdk": "~1.3",
-    "amqp": "~0.2.6",
-    "zeromq": "~4.1.1"
+    "async": "1.5.x",
+    "aws-sdk": "2.20.x",
+    "amqp": "0.2.x",
+    "zeromq": "4.1.x"
   },
   "devDependencies": {
-    "proxyquire": "^1.7.11",
-    "sinon": "^1.17.7",
-    "tap": "^10.1.2"
+    "proxyquire": "1.7.x",
+    "sinon": "1.17.x",
+    "tap": "10.2.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Addresses first task in #4.  After updating SQS, it now supports the recommended pattern of getting credentials from environment.  Updated docs and examples to reflect this.  async updated to latest 1.x.x version that didn't feature breaking changes.  Used 1.2.x syntax in `package.json`.  I feel that this indicates better intent than the ^ / ~ methods.