### PR TITLE
Convert variables declaration to const/let

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "4"
   - "6"
 script: npm run cover

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "4"
     - nodejs_version: "6"
 
 install:

--- a/examples/amqp.simple.js
+++ b/examples/amqp.simple.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var mq = require('../');
+const mq = require('../');
 
-var queue = mq.connect('amqp://127.0.0.1:5672/hello', {
+const queue = mq.connect('amqp://127.0.0.1:5672/hello', {
   exchangeName: 'helloExchange'
 });
 queue.on('ready', function() {

--- a/examples/sqs.simple.js
+++ b/examples/sqs.simple.js
@@ -1,6 +1,6 @@
-var mq = require('../index.js');
+const mq = require('../index.js');
 
-var queue = mq.connect('sqs://hello', {
+const queue = mq.connect('sqs://hello', {
 
   // delete the message after emitting 'message' event
   deleteAfterReceive: true,

--- a/examples/zero.simple.js
+++ b/examples/zero.simple.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var mq = require('../');
+const mq = require('../');
 
-var queue = mq.connect('zmq://127.0.0.1:5555/hello');
+const queue = mq.connect('zmq://127.0.0.1:5555/hello');
 queue.on('ready', function() {
   console.log('queue ready');
   startPublishing(function() {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var parseUrl = require('url').parse;
-var Queue = require('./lib/queue');
+const assert = require('assert');
+const parseUrl = require('url').parse;
+const Queue = require('./lib/queue');
 
 module.exports = exports = {
   connect: function(url, options) {

--- a/lib/providers/amqp.js
+++ b/lib/providers/amqp.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var async = require('async');
-var amqp = require('amqp');
+const assert = require('assert');
+const async = require('async');
+const amqp = require('amqp');
 
 function AmqpProvider(emitter, options) {
   assert(emitter, '`emitter` argument is not set.');
@@ -18,9 +18,9 @@ function AmqpProvider(emitter, options) {
 }
 
 AmqpProvider.prototype.publish = function(message) {
-  var self = this;
-  var publishFunc = function() {
-    var messageStr = typeof message !== 'string' ?
+  const self = this;
+  const publishFunc = function() {
+    const messageStr = typeof message !== 'string' ?
                      message instanceof Buffer ?
                      message.toString('base64') :
                      JSON.stringify(message) :
@@ -37,11 +37,11 @@ AmqpProvider.prototype.publish = function(message) {
 };
 
 AmqpProvider.prototype.subscribe = function() {
-  var self = this;
-  var subscribeFunc = function() {
+  const self = this;
+  const subscribeFunc = function() {
     self._queue.subscribe(function(msg) {
-      var isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
-      var message = msg.data.toString();
+      const isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
+      let message = msg.data.toString();
 
       // first try to detect if it is a base64 string
       // if so convert to Buffer
@@ -69,7 +69,7 @@ AmqpProvider.prototype.subscribe = function() {
 };
 
 AmqpProvider.prototype.unsubscribe = function() {
-  var self = this;
+  const self = this;
   process.nextTick(function() {
     self._isClosed = true;
     self._queue.unsubscribe(self._ctag);
@@ -84,11 +84,11 @@ AmqpProvider.prototype.close = function() {
 };
 
 AmqpProvider.prototype._initProvider = function() {
-  var self = this;
+  const self = this;
   async.series([
 
     function(cb) {
-      var conn = self._connection = amqp.createConnection(self.options);
+      const conn = self._connection = amqp.createConnection(self.options);
       conn.on('ready', cb);
     },
 

--- a/lib/providers/sqs.js
+++ b/lib/providers/sqs.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var async = require('async');
-var AWS = require('aws-sdk');
+const assert = require('assert');
+const async = require('async');
+const AWS = require('aws-sdk');
 
 function SqsProvider(emitter, options) {
   assert(emitter, '`emitter` argument is not set.');
@@ -25,9 +25,9 @@ function SqsProvider(emitter, options) {
 }
 
 SqsProvider.prototype.publish = function(message) {
-  var self = this;
-  var publishFunc = function() {
-    var messageStr = typeof message !== 'string' ?
+  const self = this;
+  const publishFunc = function() {
+    const messageStr = typeof message !== 'string' ?
                      message instanceof Buffer ?
                      message.toString('base64') :
                      JSON.stringify(message) :
@@ -57,16 +57,16 @@ SqsProvider.prototype.ack = function(messageId) {
 };
 
 SqsProvider.prototype.unsubscribe = function() {
-  var self = this;
+  const self = this;
   process.nextTick(function() {
     self._isClosed = true;
   });
 };
 
 SqsProvider.prototype._deleteMessage = function(receiptHandle) {
-  var self = this;
+  const self = this;
 
-  var param = {
+  const param = {
     QueueUrl: self._queueUrl,
     ReceiptHandle: receiptHandle
   };
@@ -79,8 +79,8 @@ SqsProvider.prototype._deleteMessage = function(receiptHandle) {
 };
 
 SqsProvider.prototype._initProvider = function() {
-  var self = this;
-  var param = { QueueName: self._q };
+  const self = this;
+  const param = { QueueName: self._q };
 
   self._sqs.getQueueUrl(param, function(err, data) {
     if (err) {
@@ -92,9 +92,9 @@ SqsProvider.prototype._initProvider = function() {
 };
 
 SqsProvider.prototype._createQueue = function(getQueueUrlError) {
-  var self = this;
+  const self = this;
 
-  var param = {
+  const param = {
     QueueName: self._q,
     Attributes: self.options.attributes
   };
@@ -118,9 +118,9 @@ SqsProvider.prototype._setQueueReady = function(queueUrl) {
 };
 
 SqsProvider.prototype._poll = function(done) {
-  var self = this;
+  const self = this;
 
-  var param = {
+  const param = {
     QueueUrl: self._queueUrl,
     MaxNumberOfMessages: self.options.maxReceiveCount || 1
   };
@@ -141,8 +141,8 @@ SqsProvider.prototype._poll = function(done) {
     }
 
     (data.Messages || []).forEach(function(msg) {
-      var decoded = msg.Body;
-      var isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
+      const isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
+      let decoded = msg.Body;
 
       // first try to detect if it is a base64 string
       // if so convert to Buffer
@@ -168,9 +168,9 @@ SqsProvider.prototype._poll = function(done) {
 };
 
 SqsProvider.prototype._sendMessage = function(message) {
-  var self = this;
+  const self = this;
 
-  var param = {
+  const param = {
     QueueUrl: self._queueUrl,
     MessageBody: message
   };
@@ -183,7 +183,7 @@ SqsProvider.prototype._sendMessage = function(message) {
 };
 
 SqsProvider.prototype._startPolling = function() {
-  var self = this;
+  const self = this;
   self._isClosed = false;
 
   async.until(

--- a/lib/providers/zmq.js
+++ b/lib/providers/zmq.js
@@ -1,6 +1,8 @@
-var assert = require('assert');
-var async = require('async');
-var zmq = require('zeromq');
+'use strict';
+
+const assert = require('assert');
+const async = require('async');
+const zmq = require('zeromq');
 
 function ZeroMqProvider(emitter, options) {
   assert(emitter, '`emitter` argument is not set.');
@@ -19,10 +21,10 @@ function ZeroMqProvider(emitter, options) {
 }
 
 ZeroMqProvider.prototype.publish = function(message) {
-  var self = this;
+  const self = this;
 
-  var publishFunc = function() {
-    var messageStr = typeof message !== 'string' ?
+  const publishFunc = function() {
+    const messageStr = typeof message !== 'string' ?
                      message instanceof Buffer ?
                      message.toString('base64') :
                      JSON.stringify(message) :
@@ -41,7 +43,7 @@ ZeroMqProvider.prototype.publish = function(message) {
 };
 
 ZeroMqProvider.prototype.subscribe = function() {
-  var self = this;
+  const self = this;
 
   if (self.emitter.isReady) {
     process.nextTick(self._connectSubscriber.bind(self));
@@ -53,7 +55,7 @@ ZeroMqProvider.prototype.subscribe = function() {
 };
 
 ZeroMqProvider.prototype.unsubscribe = function() {
-  var self = this;
+  const self = this;
   process.nextTick(function() {
     if (!self._isClosed) {
       self._isClosed = true;
@@ -67,7 +69,7 @@ ZeroMqProvider.prototype.close = function() {
 }
 
 ZeroMqProvider.prototype._initProvider = function() {
-  var self = this;
+  const self = this;
 
   self._pubSock.bind(self._url, function(err) {
     if (err) {
@@ -82,14 +84,14 @@ ZeroMqProvider.prototype._initProvider = function() {
 };
 
 ZeroMqProvider.prototype._connectSubscriber = function() {
-  var self = this;
+  const self = this;
 
   self._subSock.connect(self._url);
   self._subSock.subscribe(self._q);
 
   self._subSock.on('message', function(topic, data) {
     data = data.toString('ascii').replace(new RegExp('^'+self._q+' '), '');
-    var isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
+    const isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
 
     // first try to detect if it is a base64 string
     // if so convert to Buffer
@@ -109,7 +111,7 @@ ZeroMqProvider.prototype._connectSubscriber = function() {
 };
 
 ZeroMqProvider.prototype._sendMessage = function(message) {
-  var self = this;
+  const self = this;
 
   try {
     // It is necessary to prepend the queue name to the message

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
 
 // load providers into an object for dynamic referencing
-var Providers = {
+const Providers = {
   amqp: require('./providers/amqp'),
   sqs: require('./providers/sqs'),
   zmq: require('./providers/zmq')
@@ -16,7 +16,7 @@ function Queue(options) {
   try {
     this._provider = new Providers[options.provider](this, options);
   } catch (e) {
-    var err = new Error('Unable to instantiate provider.');
+    const err = new Error('Unable to instantiate provider.');
     err.provider = options.provider;
     err.inner = e;
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var proxyquire = require('proxyquire');
-var sinon = require('sinon');
-var tap = require('tap');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const tap = require('tap');
 
-var QueueStub = sinon.stub();
+const QueueStub = sinon.stub();
 
-var mq = proxyquire('../', {
+const mq = proxyquire('../', {
   './lib/queue': QueueStub
 });
 
@@ -46,8 +46,8 @@ tap.test('Throw an error if options object does not contain a `queueName` proper
 });
 
 tap.test('Instantiates a new queue', function(t) {
-  var queue = mq.connect('test://queue');
-  var expectedOptions = {
+  const queue = mq.connect('test://queue');
+  const expectedOptions = {
     provider: 'test',
     queueName: 'queue'
   };
@@ -60,11 +60,11 @@ tap.test('Instantiates a new queue', function(t) {
 });
 
 tap.test('Instantiates a new queue when using options object', function(t) {
-  var options = {
+  const options = {
     provider: 'test',
     queueName: 'queue'
   };
-  var queue = mq.connect(options);
+  const queue = mq.connect(options);
 
   t.ok(QueueStub.calledWithNew(), 'Queue did not instantiate.');
   t.equal(QueueStub.getCall(0).args[0], options);
@@ -72,8 +72,8 @@ tap.test('Instantiates a new queue when using options object', function(t) {
 });
 
 tap.test('Instantiates a new queue when string URL and options object', function(t) {
-  var queue = mq.connect('test://queue', { customProperty: 'test' });
-  var expectedOptions = {
+  const queue = mq.connect('test://queue', { customProperty: 'test' });
+  const expectedOptions = {
     provider: 'test',
     queueName: 'queue',
     customProperty: 'test'

--- a/test/lib/providers/amqp.js
+++ b/test/lib/providers/amqp.js
@@ -1,26 +1,24 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
-var proxyquire = require('proxyquire').noCallThru();
-var sinon = require('sinon');
-var tap = require('tap');
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+const tap = require('tap');
 
-var AmqpQueueStub = function() { };
-var AmqpExchangeStub = function() { };
-var AmqpConnectionStub = function() { };
+const AmqpQueueStub = function() { };
+const AmqpExchangeStub = function() { };
+const AmqpConnectionStub = function() { };
 util.inherits(AmqpConnectionStub, EventEmitter);
 
-var amqpStub = {
-  createConnection: sinon.stub()
-};
+const amqpStub = { createConnection: sinon.stub() };
 
-var AmqpProvider = proxyquire('../../../lib/providers/amqp', {
+const AmqpProvider = proxyquire('../../../lib/providers/amqp', {
   'amqp': amqpStub
 });
 
-var SubscribePromise = function() { };
-var fakeConsumerTag = 'test123';
+const SubscribePromise = function() { };
+const fakeConsumerTag = 'test123';
 
 
 tap.beforeEach(function(done) {
@@ -57,14 +55,14 @@ tap.test('Throws an error if `options` args is not set', function(t) {
 });
 
 tap.test('Throws an error if `options` args is missing `queueName` property', function(t) {
-  var providerOptions = {};
+  const providerOptions = {};
 
   t.throws(function() { new AmqpProvider({}, providerOptions); }, { message: /queueName.+not.+set/i });
   t.end();
 });
 
 tap.test('Throws an error if `options` args is missing `exchangeName` property', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue'
   };
 
@@ -73,7 +71,7 @@ tap.test('Throws an error if `options` args is missing `exchangeName` property',
 });
 
 tap.test('Does not throw an error if args are valid', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
@@ -85,11 +83,11 @@ tap.test('Does not throw an error if args are valid', function(t) {
 });
 
 tap.test('Creates a connection with provider options', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var provider = new AmqpProvider(new EventEmitter(), providerOptions);
+  const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
@@ -100,11 +98,11 @@ tap.test('Creates a connection with provider options', function(t) {
 });
 
 tap.test('Creates an exchange using specified name', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var provider = new AmqpProvider(new EventEmitter(), providerOptions);
+  const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
@@ -120,11 +118,11 @@ tap.test('Creates an exchange using specified name', function(t) {
 });
 
 tap.test('Creates a queue using specified name', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var provider = new AmqpProvider(new EventEmitter(), providerOptions);
+  const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
@@ -138,11 +136,11 @@ tap.test('Creates a queue using specified name', function(t) {
 });
 
 tap.test('Binds the queue to the exchange', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var provider = new AmqpProvider(new EventEmitter(), providerOptions);
+  const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
@@ -157,12 +155,12 @@ tap.test('Binds the queue to the exchange', function(t) {
 });
 
 tap.test('Sets emmitter to ready', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
   setTimeout(function() { provider._connection.emit('ready'); }, 10);
@@ -174,13 +172,13 @@ tap.test('Sets emmitter to ready', function(t) {
 });
 
 tap.test('Calls publish function with string message', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var message = 'test message';
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   provider.publish(message);
 
@@ -198,13 +196,13 @@ tap.test('Calls publish function with string message', function(t) {
 });
 
 tap.test('Calls publish function with JSON string', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var message = { test: 'obj', foo: 'bar' };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const message = { test: 'obj', foo: 'bar' };
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   provider.publish(message);
 
@@ -222,13 +220,13 @@ tap.test('Calls publish function with JSON string', function(t) {
 });
 
 tap.test('Calls publish function with Buffer', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   provider.publish(message);
 
@@ -246,13 +244,13 @@ tap.test('Calls publish function with Buffer', function(t) {
 });
 
 tap.test('Calls publish function when already... "ready"', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var message = 'test message';
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
   setTimeout(function() { provider._connection.emit('ready'); }, 10);
@@ -269,12 +267,12 @@ tap.test('Calls publish function when already... "ready"', function(t) {
 });
 
 tap.test('Subscribes to the queue with a listener', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
@@ -291,12 +289,12 @@ tap.test('Subscribes to the queue with a listener', function(t) {
 });
 
 tap.test('Emits a string message event after subscribing', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
@@ -304,8 +302,8 @@ tap.test('Emits a string message event after subscribing', function(t) {
 
   emitter.once('ready', function() {
     setTimeout(function() {
-      var handler = provider._queue.subscribe.getCall(0).args[0];
-      var originalMessage = 'test message';
+      const handler = provider._queue.subscribe.getCall(0).args[0];
+      const originalMessage = 'test message';
       emitter.on('message', function(message) {
         t.equal(message, originalMessage);
         t.end();
@@ -317,12 +315,12 @@ tap.test('Emits a string message event after subscribing', function(t) {
 });
 
 tap.test('Emits an object message event after subscribing', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
@@ -330,8 +328,8 @@ tap.test('Emits an object message event after subscribing', function(t) {
 
   emitter.once('ready', function() {
     setTimeout(function() {
-      var handler = provider._queue.subscribe.getCall(0).args[0];
-      var originalMessage = { test: 'test', foo: 'bar' };
+      const handler = provider._queue.subscribe.getCall(0).args[0];
+      const originalMessage = { test: 'test', foo: 'bar' };
       emitter.on('message', function(message) {
         t.same(message, originalMessage);
         t.end();
@@ -343,12 +341,12 @@ tap.test('Emits an object message event after subscribing', function(t) {
 });
 
 tap.test('Emits a Buffer message event after subscribing', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
@@ -356,8 +354,8 @@ tap.test('Emits a Buffer message event after subscribing', function(t) {
 
   emitter.once('ready', function() {
     setTimeout(function() {
-      var handler = provider._queue.subscribe.getCall(0).args[0];
-      var originalMessage = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const handler = provider._queue.subscribe.getCall(0).args[0];
+      const originalMessage = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
       emitter.on('message', function(message) {
         t.same(message, originalMessage);
         t.end();
@@ -369,12 +367,12 @@ tap.test('Emits a Buffer message event after subscribing', function(t) {
 });
 
 tap.test('Subcribes to the queue with a listener when already... "ready"', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
   setTimeout(function() { provider._connection.emit('ready'); }, 10);
@@ -390,12 +388,12 @@ tap.test('Subcribes to the queue with a listener when already... "ready"', funct
 });
 
 tap.test('Unsubscribes from the queue the queue', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
@@ -414,12 +412,12 @@ tap.test('Unsubscribes from the queue the queue', function(t) {
 });
 
 tap.test('Unbinds from the queue on close', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
   setTimeout(function() { provider._connection.emit('ready'); }, 10);
@@ -436,12 +434,12 @@ tap.test('Unbinds from the queue on close', function(t) {
 });
 
 tap.test('Destroys the exchange and queue on close', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
   setTimeout(function() { provider._connection.emit('ready'); }, 10);
@@ -457,12 +455,12 @@ tap.test('Destroys the exchange and queue on close', function(t) {
 });
 
 tap.test('Disconnects the connection on close', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
-  var emitter = new EventEmitter();
-  var provider = new AmqpProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
   setTimeout(function() { provider._connection.emit('ready'); }, 10);

--- a/test/lib/providers/sqs.js
+++ b/test/lib/providers/sqs.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
-var proxyquire = require('proxyquire').noCallThru();
-var sinon = require('sinon');
-var tap = require('tap');
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+const tap = require('tap');
 
-var skip = false;
+let skip = false;
 
-var AWSStub = {
+const AWSStub = {
   config: {},
   SQS: sinon.stub()
 };
 
-var SqsProvider = proxyquire('../../../lib/providers/sqs', {
+const SqsProvider = proxyquire('../../../lib/providers/sqs', {
   'aws-sdk': AWSStub
 });
 
-var fakeQueueUrl = 'https://fake.sqs.url/test';
+const fakeQueueUrl = 'https://fake.sqs.url/test';
 
 tap.beforeEach(function(done) {
   AWSStub.SQS = sinon.stub();
@@ -50,14 +50,14 @@ tap.test('Throws an error if `options` args is not set', function(t) {
 });
 
 tap.test('Throws an error if `options` args is missing `queueName` property', function(t) {
-  var providerOptions = {};
+  const providerOptions = {};
 
   t.throws(function() { new SqsProvider({}, providerOptions); }, { message: /queueName.+not.+set/i });
   t.end();
 });
 
 tap.test('Does not throw an error if args are valid', function(t) {
-  var providerOptions = { queueName: 'queue' };
+  const providerOptions = { queueName: 'queue' };
 
   sinon.stub(SqsProvider.prototype, '_initProvider', function() { });
   t.doesNotThrow(function() { new SqsProvider({}, providerOptions); });
@@ -66,7 +66,7 @@ tap.test('Does not throw an error if args are valid', function(t) {
 });
 
 tap.test('Loads AWS config from a file if `awsConfig` is a string', function(t) {
-  var providerOptions =
+  const providerOptions =
   {
     queueName: 'queue',
     awsConfig: '/a/fake/aws/config'
@@ -81,7 +81,7 @@ tap.test('Loads AWS config from a file if `awsConfig` is a string', function(t) 
 });
 
 tap.test('Update AWS config from `awsConfig` object when set', function(t) {
-  var providerOptions =
+  const providerOptions =
   {
     queueName: 'queue',
     awsConfig: { some: 'aws', config: true }
@@ -96,10 +96,10 @@ tap.test('Update AWS config from `awsConfig` object when set', function(t) {
 });
 
 tap.test('Instantiates a new `AWS.SQS` object', function(t) {
-  var providerOptions = { queueName: 'queue' };
+  const providerOptions = { queueName: 'queue' };
 
   sinon.stub(SqsProvider.prototype, '_initProvider', function() { });
-  var provider = new SqsProvider({}, providerOptions);
+  const provider = new SqsProvider({}, providerOptions);
   t.ok(AWSStub.SQS.calledWithNew(), '`AWS.SQS` object was not instantiated.');
   t.type(provider._sqs, AWSStub.SQS);
   SqsProvider.prototype._initProvider.restore();
@@ -107,27 +107,27 @@ tap.test('Instantiates a new `AWS.SQS` object', function(t) {
 });
 
 tap.test('Gets the QueueUrl on provider init', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var provider = new SqsProvider(new EventEmitter(), providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const provider = new SqsProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
-    var expectedParams = { QueueName: providerOptions.queueName };
+    const expectedParams = { QueueName: providerOptions.queueName };
     t.ok(provider._sqs.getQueueUrl.called);
     t.same(provider._sqs.getQueueUrl.getCall(0).args[0], expectedParams);
     t.equal(typeof provider._sqs.getQueueUrl.getCall(0).args[1], 'function');
     t.end();
-  }, 10);
+  }, 20);
 });
 
 tap.test('Creates the queue on provider init if error callback from SQS `getQueueUrl`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var provider = new SqsProvider(new EventEmitter(), providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const provider = new SqsProvider(new EventEmitter(), providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
-    var expectedParams = { QueueName: providerOptions.queueName };
+    const expectedParams = { QueueName: providerOptions.queueName };
     t.ok(provider._sqs.createQueue.called);
     t.match(provider._sqs.createQueue.getCall(0).args[0], expectedParams);
     t.equal(typeof provider._sqs.createQueue.getCall(0).args[1], 'function');
@@ -136,16 +136,16 @@ tap.test('Creates the queue on provider init if error callback from SQS `getQueu
 });
 
 tap.test('Creates or retrieves a QueueUrl on provider init (with attributes)', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     attributes: { custom: 'attributes' }
   };
-  var provider = new SqsProvider(new EventEmitter(), providerOptions);
+  const provider = new SqsProvider(new EventEmitter(), providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
-    var expectedParams = {
+    const expectedParams = {
       QueueName: providerOptions.queueName,
       Attributes: providerOptions.attributes
     };
@@ -155,9 +155,9 @@ tap.test('Creates or retrieves a QueueUrl on provider init (with attributes)', f
 });
 
 tap.test('Emits "ready" event on call back from `getQueueUrl`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   emitter.on('ready', function() {
     t.ok(emitter.isReady);
@@ -166,9 +166,9 @@ tap.test('Emits "ready" event on call back from `getQueueUrl`', function(t) {
 });
 
 tap.test('Emits "ready" event on call back from `createQueue`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
 
   emitter.on('ready', function() {
@@ -178,10 +178,10 @@ tap.test('Emits "ready" event on call back from `createQueue`', function(t) {
 });
 
 tap.test('Sets `_queueUrl` property with value called back from `getQueueUrl`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var queueData = { QueueUrl: 'https://fake.sqs.url/test' };
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const queueData = { QueueUrl: 'https://fake.sqs.url/test' };
+  const provider = new SqsProvider(emitter, providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, null, queueData);
 
   emitter.on('ready', function() {
@@ -191,10 +191,10 @@ tap.test('Sets `_queueUrl` property with value called back from `getQueueUrl`', 
 });
 
 tap.test('Sets `_queueUrl` property with value called back from `createQueue`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var queueData = { QueueUrl: 'https://fake.sqs.url/test' };
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const queueData = { QueueUrl: 'https://fake.sqs.url/test' };
+  const provider = new SqsProvider(emitter, providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
   provider._sqs.createQueue.callsArgWith(1, null, queueData);
 
@@ -205,11 +205,11 @@ tap.test('Sets `_queueUrl` property with value called back from `createQueue`', 
 });
 
 tap.test('Emits "error" event twice if error called back from `createQueue`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var getQueueUrlError = new Error('getQueueUrl error');
-  var createError = new Error('createQueue error');
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const getQueueUrlError = new Error('getQueueUrl error');
+  const createError = new Error('createQueue error');
+  const provider = new SqsProvider(emitter, providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, getQueueUrlError);
   provider._sqs.createQueue.callsArgWith(1, createError);
 
@@ -223,17 +223,17 @@ tap.test('Emits "error" event twice if error called back from `createQueue`', fu
 });
 
 tap.test('Calls publish function with string message', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var message = 'test message';
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   provider.publish(message);
 
   emitter.once('ready', function() {
     // Defer this test to wait for all deferred methods in provider to run
     setTimeout(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: message
       };
@@ -247,17 +247,17 @@ tap.test('Calls publish function with string message', function(t) {
 });
 
 tap.test('Calls publish function with JSON string', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var message = { test: 'obj', foo: 'bar' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const message = { test: 'obj', foo: 'bar' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   provider.publish(message);
 
   emitter.once('ready', function() {
     // Defer this test to wait for all deferred methods in provider to run
     setTimeout(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: JSON.stringify(message)
       };
@@ -270,17 +270,17 @@ tap.test('Calls publish function with JSON string', function(t) {
 });
 
 tap.test('Calls publish function with Buffer', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   provider.publish(message);
 
   emitter.once('ready', function() {
     // Defer this test to wait for all deferred methods in provider to run
     setTimeout(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: message.toString('base64')
       };
@@ -293,15 +293,15 @@ tap.test('Calls publish function with Buffer', function(t) {
 });
 
 tap.test('Calls publish function when already... "ready"', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var message = 'test message';
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   emitter.once('ready', function() {
     provider.publish(message);
     setTimeout(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: message
       };
@@ -314,10 +314,10 @@ tap.test('Calls publish function when already... "ready"', function(t) {
 });
 
 tap.test('Emits "error" event if error called back from `sendMessage`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var expectedError = new Error('Test error');
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const expectedError = new Error('Test error');
+  const provider = new SqsProvider(emitter, providerOptions);
   AWSStub.SQS.prototype.sendMessage = sinon.stub().callsArgWith(1, expectedError);
 
   provider.publish('test message');
@@ -329,9 +329,9 @@ tap.test('Emits "error" event if error called back from `sendMessage`', function
 });
 
 tap.test('Starts polling if subscribing before ready event', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
   provider._startPolling = sinon.stub();
 
   provider.subscribe();
@@ -345,9 +345,9 @@ tap.test('Starts polling if subscribing before ready event', function(t) {
 });
 
 tap.test('Starts polling if subscribing after ready event', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
   provider._startPolling = sinon.stub();
 
   emitter.once('ready', function(err) {
@@ -360,9 +360,9 @@ tap.test('Starts polling if subscribing after ready event', function(t) {
 });
 
 tap.test('Sets `_isClosed` property to true on unsubscribe', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   t.notOk(provider._isClosed);
   provider.unsubscribe();
@@ -378,9 +378,9 @@ if (process.platform === 'win32') {
 }
 
 tap.test('`_poll` method is called repeatedly until unsubscribed', { skip: skip }, function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
   sinon.stub(provider, '_poll', function(cb) {
     setTimeout(cb, 10);
   });
@@ -397,12 +397,12 @@ tap.test('`_poll` method is called repeatedly until unsubscribed', { skip: skip 
 });
 
 tap.test('`_poll` method is called with delay as set in options', { skip: skip }, function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     delayBetweenPolls: 0.01 // 10 milliseconds
   };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
   sinon.stub(provider, '_poll', function(cb) {
     setTimeout(cb, 10);
   });
@@ -420,13 +420,13 @@ tap.test('`_poll` method is called with delay as set in options', { skip: skip }
 });
 
 tap.test('`_poll` calls the SQS `_receiveMessage` with default params', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   emitter.once('ready', function() {
     provider._poll(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 1
       };
@@ -438,16 +438,16 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with default params', function
 });
 
 tap.test('`_poll` calls the SQS `_receiveMessage` with max number of messages set', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     maxReceiveCount: 10
   };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   emitter.once('ready', function() {
     provider._poll(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 10
       };
@@ -458,16 +458,16 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with max number of messages se
 });
 
 tap.test('`_poll` calls the SQS `_receiveMessage` with custom visibility timeout set', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     visibilityTimeout: 10
   };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   emitter.once('ready', function() {
     provider._poll(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 1,
         VisibilityTimeout: 10,
@@ -480,16 +480,16 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with custom visibility timeout
 });
 
 tap.test('`_poll` calls the SQS `_receiveMessage` with custom wait time seconds set', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     waitTimeSeconds: 10
   };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   emitter.once('ready', function() {
     provider._poll(function() {
-      var expectedParams = {
+      const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 1,
         WaitTimeSeconds: 10
@@ -501,9 +501,9 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with custom wait time seconds 
 });
 
 tap.test('`_poll` does not emit a "message" event if no messages returned from SQS `_receiveMessage`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
 
   emitter.once('message', function() {
     t.fail('"message" event should not be called');
@@ -517,10 +517,10 @@ tap.test('`_poll` does not emit a "message" event if no messages returned from S
 });
 
 tap.test('`_poll` emits error on SQS `_receiveMessage` callback error', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var testError = new Error('Test error');
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const testError = new Error('Test error');
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, testError);
 
   setTimeout(function() {
@@ -534,10 +534,10 @@ tap.test('`_poll` emits error on SQS `_receiveMessage` callback error', function
 });
 
 tap.test('`_poll` emits a string message event', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var data = {
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const data = {
     Messages: [{ Body: 'Test Message 1', ReceiptHandle: 'abc' }]
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
@@ -554,11 +554,11 @@ tap.test('`_poll` emits a string message event', function(t) {
 });
 
 tap.test('`_poll` emits an object message event', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var message = { test: 'message', foo: 'bar' };
-  var data = {
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const message = { test: 'message', foo: 'bar' };
+  const data = {
     Messages: [{ Body: JSON.stringify(message), ReceiptHandle: 'abc' }]
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
@@ -575,11 +575,11 @@ tap.test('`_poll` emits an object message event', function(t) {
 });
 
 tap.test('`_poll` emits a Buffer message event', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  var data = {
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  const data = {
     Messages: [{ Body: message.toString('base64'), ReceiptHandle: 'abc' }]
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
@@ -596,14 +596,14 @@ tap.test('`_poll` emits a Buffer message event', function(t) {
 });
 
 tap.test('Calls `_deleteMessage` if `deleteAfterReceive` is true', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     deleteAfterReceive: true
   };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var message = 'test';
-  var data = {
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const message = 'test';
+  const data = {
     Messages: [{ Body: message.toString('base64'), ReceiptHandle: 'abc' }]
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
@@ -619,14 +619,14 @@ tap.test('Calls `_deleteMessage` if `deleteAfterReceive` is true', function(t) {
 });
 
 tap.test('Does not call `_deleteMessage` if already unsubscribed', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     deleteAfterReceive: true
   };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var message = 'test';
-  var data = {
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const message = 'test';
+  const data = {
     Messages: [{ Body: message.toString('base64'), ReceiptHandle: 'abc' }]
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
@@ -644,10 +644,10 @@ tap.test('Does not call `_deleteMessage` if already unsubscribed', function(t) {
 });
 
 tap.test('`ack` calls `_deleteMessage`', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var messageId = 'test';
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const messageId = 'test';
   provider._deleteMessage = sinon.stub();
 
   emitter.once('ready', function() {
@@ -661,12 +661,12 @@ tap.test('`ack` calls `_deleteMessage`', function(t) {
 });
 
 tap.test('Ignores `ack` if `deleteAfterReceive` is set to true', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     deleteAfterReceive: true
   };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
   provider._deleteMessage = sinon.stub();
 
   emitter.once('ready', function() {
@@ -679,10 +679,10 @@ tap.test('Ignores `ack` if `deleteAfterReceive` is set to true', function(t) {
 });
 
 tap.test('`_deleteMessage` calls the SQS `deleteMessage` method', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var expectedParams = {
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const expectedParams = {
     QueueUrl: fakeQueueUrl,
     ReceiptHandle: 'test'
   };
@@ -697,10 +697,10 @@ tap.test('`_deleteMessage` calls the SQS `deleteMessage` method', function(t) {
 });
 
 tap.test('Emits "error" event if SQS `deleteMessage` calls back an error', function(t) {
-  var providerOptions = { queueName: 'queue' };
-  var emitter = new EventEmitter();
-  var provider = new SqsProvider(emitter, providerOptions);
-  var testError = new Error('test error');
+  const providerOptions = { queueName: 'queue' };
+  const emitter = new EventEmitter();
+  const provider = new SqsProvider(emitter, providerOptions);
+  const testError = new Error('test error');
   provider._sqs.deleteMessage = sinon.stub().callsArgWith(1, testError);
 
   emitter.once('error', function(err) {

--- a/test/lib/providers/zmq.js
+++ b/test/lib/providers/zmq.js
@@ -1,23 +1,21 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
-var proxyquire = require('proxyquire').noCallThru();
-var sinon = require('sinon');
-var tap = require('tap');
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+const tap = require('tap');
 
-var ZmqSocket = function() { };
+const ZmqSocket = function() { };
 util.inherits(ZmqSocket, EventEmitter);
 
-var zmqStub = {
-  socket: sinon.stub()
-};
+const zmqStub = { socket: sinon.stub() };
 
-var ZmqProvider = proxyquire('../../../lib/providers/zmq', {
+const ZmqProvider = proxyquire('../../../lib/providers/zmq', {
   'zeromq': zmqStub
 });
 
-var validOptions = {
+const validOptions = {
   queueName: 'queue',
   hostname: 'test',
   port: 1234
@@ -47,14 +45,14 @@ tap.test('Throws an error if `options` args is not set', function(t) {
 });
 
 tap.test('Throws an error if `options` args is missing `queueName` property', function(t) {
-  var providerOptions = {};
+  const providerOptions = {};
 
   t.throws(function() { new ZmqProvider({}, providerOptions); }, { message: /queueName.+not.+set/i });
   t.end();
 });
 
 tap.test('Throws an error if `options` args is missing `hostname` property', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue'
   };
 
@@ -63,7 +61,7 @@ tap.test('Throws an error if `options` args is missing `hostname` property', fun
 });
 
 tap.test('Throws an error if `options` args is missing `port` property', function(t) {
-  var providerOptions = {
+  const providerOptions = {
     queueName: 'queue',
     hostname: 'test'
   };
@@ -80,7 +78,7 @@ tap.test('Does not throw an error if args are valid', function(t) {
 });
 
 tap.test('Creates a sub socket', function(t) {
-  var provider = new ZmqProvider(new EventEmitter(), validOptions);
+  const provider = new ZmqProvider(new EventEmitter(), validOptions);
 
   t.ok(zmqStub.socket.calledWith('sub'));
   t.ok(provider._subSock);
@@ -88,7 +86,7 @@ tap.test('Creates a sub socket', function(t) {
 });
 
 tap.test('Creates a pub socket', function(t) {
-  var provider = new ZmqProvider(new EventEmitter(), validOptions);
+  const provider = new ZmqProvider(new EventEmitter(), validOptions);
 
   t.ok(zmqStub.socket.calledWith('pub'));
   t.ok(provider._pubSock);
@@ -96,8 +94,8 @@ tap.test('Creates a pub socket', function(t) {
 });
 
 tap.test('Binds to the pub socket', function(t) {
-  var provider = new ZmqProvider(new EventEmitter(), validOptions);
-  var expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
+  const provider = new ZmqProvider(new EventEmitter(), validOptions);
+  const expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
 
   // Defer these tests since provider is initialized on next event loop
   setTimeout(function() {
@@ -109,7 +107,7 @@ tap.test('Binds to the pub socket', function(t) {
 });
 
 tap.test('Sets emmitter to ready once bound to pub socket', function(t) {
-  var emitter = new EventEmitter();
+  const emitter = new EventEmitter();
   new ZmqProvider(emitter, validOptions);
 
   emitter.once('ready', function() {
@@ -119,9 +117,9 @@ tap.test('Sets emmitter to ready once bound to pub socket', function(t) {
 });
 
 tap.test('Emits an error on when error called back from pub socket bind', function(t) {
-  var testError = new Error('test error');
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const testError = new Error('test error');
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
   provider._pubSock.bind = sinon.stub().callsArgWith(1, testError);
 
   emitter.once('error', function(err) {
@@ -131,15 +129,15 @@ tap.test('Emits an error on when error called back from pub socket bind', functi
 });
 
 tap.test('Calls socket `send` function with string message', function(t) {
-  var message = 'test message';
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
 
   provider.publish(message);
 
   emitter.once('ready', function() {
     setTimeout(function() {
-      var expectedMessage = [
+      const expectedMessage = [
         validOptions.queueName,
         validOptions.queueName + ' ' + message
       ];
@@ -151,15 +149,15 @@ tap.test('Calls socket `send` function with string message', function(t) {
 });
 
 tap.test('Calls socket `send` function with JSON string', function(t) {
-  var message = { test: 'obj', foo: 'bar' };
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const message = { test: 'obj', foo: 'bar' };
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
 
   provider.publish(message);
 
   emitter.once('ready', function() {
     setTimeout(function() {
-      var expectedMessage = [
+      const expectedMessage = [
         validOptions.queueName,
         validOptions.queueName + ' ' + JSON.stringify(message)
       ];
@@ -171,15 +169,15 @@ tap.test('Calls socket `send` function with JSON string', function(t) {
 });
 
 tap.test('Calls socket `send` function with Buffer', function(t) {
-  var message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
 
   provider.publish(message);
 
   emitter.once('ready', function() {
     setTimeout(function() {
-      var expectedMessage = [
+      const expectedMessage = [
         validOptions.queueName,
         validOptions.queueName + ' ' + message.toString('base64')
       ];
@@ -191,14 +189,14 @@ tap.test('Calls socket `send` function with Buffer', function(t) {
 });
 
 tap.test('Calls publish function when already... "ready"', function(t) {
-  var message = 'test message';
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
 
   emitter.once('ready', function() {
     provider.publish(message);
     setTimeout(function() {
-      var expectedMessage = [
+      const expectedMessage = [
         validOptions.queueName,
         validOptions.queueName + ' ' + message
       ];
@@ -210,10 +208,10 @@ tap.test('Calls publish function when already... "ready"', function(t) {
 });
 
 tap.test('Emits an error when socket `send` throws an error', function(t) {
-  var message = 'test message';
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
-  var testError = new Error('test error');
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
+  const testError = new Error('test error');
   provider._pubSock.send = sinon.stub().throws(testError)
   provider.publish(message);
 
@@ -224,10 +222,10 @@ tap.test('Emits an error when socket `send` throws an error', function(t) {
 });
 
 tap.test('Subcribes to the queue', function(t) {
-  var expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
-  var expectedTopic = validOptions.queueName;
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
+  const expectedTopic = validOptions.queueName;
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
   provider.subscribe();
 
   emitter.once('ready', function() {
@@ -240,9 +238,9 @@ tap.test('Subcribes to the queue', function(t) {
 });
 
 tap.test('Emits a string message event after subscribing', function(t) {
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
-  var originalMessage = 'test message';
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
+  const originalMessage = 'test message';
   provider.subscribe();
 
   emitter.on('message', function(message) {
@@ -258,9 +256,9 @@ tap.test('Emits a string message event after subscribing', function(t) {
 });
 
 tap.test('Emits an object message event after subscribing', function(t) {
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
-  var originalMessage = { test: 'test', foo: 'bar' };
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
+  const originalMessage = { test: 'test', foo: 'bar' };
   provider.subscribe();
 
   emitter.on('message', function(message) {
@@ -276,9 +274,9 @@ tap.test('Emits an object message event after subscribing', function(t) {
 });
 
 tap.test('Emits a Buffer message event after subscribing', function(t) {
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
-  var originalMessage = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
+  const originalMessage = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   provider.subscribe();
 
   emitter.on('message', function(message) {
@@ -294,10 +292,10 @@ tap.test('Emits a Buffer message event after subscribing', function(t) {
 });
 
 tap.test('Subcribes to the queue when already... "ready"', function(t) {
-  var expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
-  var expectedTopic = validOptions.queueName;
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
+  const expectedTopic = validOptions.queueName;
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
 
   emitter.once('ready', function() {
     provider.subscribe();
@@ -310,9 +308,9 @@ tap.test('Subcribes to the queue when already... "ready"', function(t) {
 });
 
 tap.test('Unsubscribing disconnects the sub socket', function(t) {
-  var expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
 
   emitter.once('ready', function() {
     provider.subscribe();
@@ -329,9 +327,9 @@ tap.test('Unsubscribing disconnects the sub socket', function(t) {
 });
 
 tap.test('Unsubscribing when queue provider is "closed" is ignored', function(t) {
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
-  var removeCount = 0;
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
+  const removeCount = 0;
 
   emitter.once('ready', function() {
     provider.subscribe();
@@ -347,9 +345,9 @@ tap.test('Unsubscribing when queue provider is "closed" is ignored', function(t)
 });
 
 tap.test('The `close` method unbinds the pub socket', function(t) {
-  var expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
-  var emitter = new EventEmitter();
-  var provider = new ZmqProvider(emitter, validOptions);
+  const expectedUrl = 'tcp://' + validOptions.hostname + ':' + validOptions.port;
+  const emitter = new EventEmitter();
+  const provider = new ZmqProvider(emitter, validOptions);
 
   emitter.once('ready', function() {
     provider.close();

--- a/test/lib/queue.js
+++ b/test/lib/queue.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var proxyquire = require('proxyquire').noCallThru();
-var sinon = require('sinon');
-var tap = require('tap');
+const EventEmitter = require('events').EventEmitter;
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+const tap = require('tap');
 
-var AmqpStub = sinon.stub();
-var SqsStub = sinon.stub();
-var ZmqStub = sinon.stub();
+const AmqpStub = sinon.stub();
+const SqsStub = sinon.stub();
+const ZmqStub = sinon.stub();
 
-var Queue = proxyquire('../../lib/queue', {
+const Queue = proxyquire('../../lib/queue', {
   './providers/amqp': AmqpStub,
   './providers/sqs': SqsStub,
   './providers/zmq': ZmqStub
@@ -23,8 +23,8 @@ tap.beforeEach(function(done) {
 });
 
 tap.test('Instantiates a new AMQP Provider', function(t) {
-  var options = { provider: 'amqp' };
-  var q = new Queue(options);
+  const options = { provider: 'amqp' };
+  const q = new Queue(options);
 
   t.ok(AmqpStub.calledWithNew(), 'AmqpProvider did not instantiate.')
   t.ok(AmqpStub.calledWith(q, options), 'AmqpProvider not called with proper args.');
@@ -33,8 +33,8 @@ tap.test('Instantiates a new AMQP Provider', function(t) {
 });
 
 tap.test('Instantiates a new SQS Provider', function(t) {
-  var options = { provider: 'sqs' };
-  var q = new Queue(options);
+  const options = { provider: 'sqs' };
+  const q = new Queue(options);
 
   t.ok(SqsStub.calledWithNew(), 'SqsProvider did not instantiate.')
   t.ok(SqsStub.calledWith(q, options), 'SqsProvider not called with proper args.');
@@ -43,8 +43,8 @@ tap.test('Instantiates a new SQS Provider', function(t) {
 });
 
 tap.test('Instantiates a new ZeroMQ Provider', function(t) {
-  var options = { provider: 'zmq' };
-  var q = new Queue(options);
+  const options = { provider: 'zmq' };
+  const q = new Queue(options);
 
   t.ok(ZmqStub.calledWithNew(), 'ZmqProvider did not instantiate.')
   t.ok(ZmqStub.calledWith(q, options), 'ZmqProvider not called with proper args.');
@@ -53,7 +53,7 @@ tap.test('Instantiates a new ZeroMQ Provider', function(t) {
 });
 
 tap.test('Throws an error if provider not specified', function(t) {
-  var expectedError = {
+  const expectedError = {
     message: /unable.+instantiate.+provider/i,
     provider: 'invalid',
     inner: {}
@@ -64,25 +64,25 @@ tap.test('Throws an error if provider not specified', function(t) {
 });
 
 tap.test('Queue is an EventEmitter', function(t) {
-  var q = new Queue({ provider: 'amqp' });
+  const q = new Queue({ provider: 'amqp' });
   t.type(q, EventEmitter);
   t.end();
 });
 
 tap.test('Queue is an EventEmitter', function(t) {
-  var q = new Queue({ provider: 'amqp' });
+  const q = new Queue({ provider: 'amqp' });
   t.type(q, EventEmitter);
   t.end();
 });
 
 tap.test('Sets `isReady` property to `false`', function(t) {
-  var q = new Queue({ provider: 'amqp' });
+  const q = new Queue({ provider: 'amqp' });
   t.equal(q.isReady, false);
   t.end();
 });
 
 tap.test('Calls provider `subscribe` method once when first listener is added', function(t) {
-  var q = new Queue({ provider: 'amqp' });
+  const q = new Queue({ provider: 'amqp' });
   q._provider.subscribe = sinon.stub();
   q.on('message', function() { });
   q.on('message', function() { });
@@ -96,7 +96,7 @@ tap.test('Calls provider `subscribe` method once when first listener is added', 
 });
 
 tap.test('Calls provider `unsubscribe` method once when last listener is removed', function(t) {
-  var q = new Queue({ provider: 'amqp' });
+  const q = new Queue({ provider: 'amqp' });
   q._provider.subscribe = sinon.stub();
   q._provider.unsubscribe = sinon.stub();
   q.on('message', function() { });
@@ -112,7 +112,7 @@ tap.test('Calls provider `unsubscribe` method once when last listener is removed
 });
 
 tap.test('Does not unsubscribe from provider if "removeListener" event name is not "message"', function(t) {
-  var q = new Queue({ provider: 'amqp' });
+  const q = new Queue({ provider: 'amqp' });
   q._provider.subscribe = sinon.stub();
   q._provider.unsubscribe = sinon.stub();
   q.on('message', function() { });
@@ -127,8 +127,8 @@ tap.test('Does not unsubscribe from provider if "removeListener" event name is n
 });
 
 tap.test('Forwards message publishing to the provider', function(t) {
-  var q = new Queue({ provider: 'amqp' });
-  var expectedMessage = 'a value';
+  const q = new Queue({ provider: 'amqp' });
+  const expectedMessage = 'a value';
   q._provider.publish = sinon.stub();
   q.publish(expectedMessage);
   t.ok(q._provider.publish.called, 'Provider `publish` not called.');
@@ -137,8 +137,8 @@ tap.test('Forwards message publishing to the provider', function(t) {
 });
 
 tap.test('Forwards message ack to the provider', function(t) {
-  var q = new Queue({ provider: 'amqp' });
-  var expectedMessageId = 'message-id';
+  const q = new Queue({ provider: 'amqp' });
+  const expectedMessageId = 'message-id';
   q._provider.ack = sinon.stub();
   q.ack(expectedMessageId);
   t.ok(q._provider.ack.called, 'Provider `ack` not called.');
@@ -147,7 +147,7 @@ tap.test('Forwards message ack to the provider', function(t) {
 });
 
 tap.test('Forwards queue close to the provider', function(t) {
-  var q = new Queue({ provider: 'amqp' });
+  const q = new Queue({ provider: 'amqp' });
   q._provider.close = sinon.stub();
   q.close();
   t.ok(q._provider.close.called, 'Provider `close` not called.');


### PR DESCRIPTION
Addresses issue #6.  Simply converts all variables to `const`/`let` where as applicable.