### PR TITLE
Convert to use arrow functions

### DIFF
--- a/examples/amqp.simple.js
+++ b/examples/amqp.simple.js
@@ -5,9 +5,9 @@ const mq = require('../');
 const queue = mq.connect('amqp://127.0.0.1:5672/hello', {
   exchangeName: 'helloExchange'
 });
-queue.on('ready', function() {
+queue.on('ready', () => {
   console.log('queue ready');
-  startPublishing(function() {
+  startPublishing(() => {
     queue.removeAllListeners('message');
     console.log('unsubscribed');
   });
@@ -15,35 +15,23 @@ queue.on('ready', function() {
   setTimeout(close, 10000)
 });
 
-queue.on('message', printMessage);
+queue.on('message', (message) => console.log(message));
+queue.on('error', (err) => console.log(err));
 
-queue.on('error', function(err) {
-  console.log(err);
-});
+function startPublishing(done) {
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 1000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 2000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 3000);
 
-function printMessage(message) {
-  console.log(message);
+  // This one will not be emitted since it occurs
+  // after the listener is removed
+  // It is included to demonstrate this behavior
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 6000);
+
+  setTimeout(done, 5000);
 }
 
 function close() {
   queue.close();
   console.log('queue closed');
 }
-
-function startPublishing(done) {
-  setTimeout(publishOne, 1000);
-  setTimeout(publishOne, 2000);
-  setTimeout(publishOne, 3000);
-
-  // This one will not be emitted since it occurs
-  // after the listener is removed
-  // It is included to demonstrate this behavior
-  setTimeout(publishOne, 6000);
-
-  setTimeout(done, 5000);
-}
-
-function publishOne() {
-  queue.publish('hello world: ' + new Date());
-}
-

--- a/examples/sqs.simple.js
+++ b/examples/sqs.simple.js
@@ -20,46 +20,33 @@ const queue = mq.connect('sqs://hello', {
 
 });
 
-queue.on('ready', function() {
+queue.on('ready', () => {
   console.log('queue ready');
-  startPublishing(function() {
+  startPublishing(() => {
     queue.removeAllListeners('message');
     console.log('unsubscribed');
   });
 
-  setTimeout(close, 10000);
+  setTimeout(() => console.log('SQS queues do not need to be closed'), 10000);
 });
 
-queue.on('message', printMessage);
-
-queue.on('error', function(err) {
+queue.on('message', (message) => console.log(message));
+queue.on('error', (err) => {
   console.log(err);
   console.log('Do you need to setup your environment with your AWS credentials?');
   console.log('http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html');
 });
 
-function printMessage(message) {
-  console.log(message);
-}
-
-function close() {
-  console.log('SQS queues do not need to be closed');
-}
-
 function startPublishing(done) {
-  setTimeout(publishOne, 1000);
-  setTimeout(publishOne, 2000);
-  setTimeout(publishOne, 3000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 1000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 2000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 3000);
 
   // This one will not be emitted since it occurs
   // after the listener is removed
   // It will however be received if you run the example again
   // It is included to demonstrate this behavior
-  setTimeout(publishOne, 9000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 9000);
 
   setTimeout(done, 8000);
-}
-
-function publishOne() {
-  queue.publish('hello world: ' + new Date());
 }

--- a/examples/zero.simple.js
+++ b/examples/zero.simple.js
@@ -3,9 +3,9 @@
 const mq = require('../');
 
 const queue = mq.connect('zmq://127.0.0.1:5555/hello');
-queue.on('ready', function() {
+queue.on('ready', () => {
   console.log('queue ready');
-  startPublishing(function() {
+  startPublishing(() => {
     queue.removeAllListeners('message');
     console.log('unsubscribed');
   });
@@ -13,35 +13,24 @@ queue.on('ready', function() {
   setTimeout(close, 10000)
 });
 
-queue.on('message', printMessage);
+queue.on('message', (message) => console.log(message));
+queue.on('error', (err) => console.log(err));
 
-queue.on('error', function(err) {
-  console.log(err);
-});
+function startPublishing(done) {
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 1000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 2000);
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 3000);
 
-function printMessage(message) {
-  console.log(message);
+  // This one will not be emitted since it occurs
+  // after the listener is removed
+  // It is included to demonstrate this behavior
+  setTimeout(() => queue.publish('hello world: ' + new Date()), 6000);
+
+  setTimeout(done, 5000);
 }
 
 function close() {
   queue.close();
   console.log('queue closed');
-}
-
-function startPublishing(done) {
-  setTimeout(publishOne, 1000);
-  setTimeout(publishOne, 2000);
-  setTimeout(publishOne, 3000);
-
-  // This one will not be emitted since it occurs
-  // after the listener is removed
-  // It is included to demonstrate this behavior
-  setTimeout(publishOne, 6000);
-
-  setTimeout(done, 5000);
-}
-
-function publishOne() {
-  queue.publish('hello world: ' + new Date());
 }
 

--- a/lib/providers/amqp.js
+++ b/lib/providers/amqp.js
@@ -14,32 +14,26 @@ function AmqpProvider(emitter, options) {
 
   this._q = options.queueName;
 
-  process.nextTick(this._initProvider.bind(this));
+  setImmediate(() => this._initProvider());
 }
 
 AmqpProvider.prototype.publish = function(message) {
-  const self = this;
-  const publishFunc = function() {
-    const messageStr = typeof message !== 'string' ?
-                     message instanceof Buffer ?
-                     message.toString('base64') :
-                     JSON.stringify(message) :
-                     message;
+  const messageStr = typeof message !== 'string' ?
+                    message instanceof Buffer ?
+                    message.toString('base64') :
+                    JSON.stringify(message) :
+                    message;
 
-    self._exchange.publish(self._q, messageStr);
-  };
-
-  if (self.emitter.isReady) {
-    process.nextTick(publishFunc);
+  if (this.emitter.isReady) {
+    setImmediate(() => this._exchange.publish(this._q, messageStr));
   } else {
-    self.emitter.once('ready', publishFunc);
+    this.emitter.once('ready', () => this._exchange.publish(this._q, messageStr));
   }
 };
 
 AmqpProvider.prototype.subscribe = function() {
-  const self = this;
   const subscribeFunc = function() {
-    self._queue.subscribe(function(msg) {
+    this._queue.subscribe((msg) => {
       const isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
       let message = msg.data.toString();
 
@@ -55,24 +49,21 @@ AmqpProvider.prototype.subscribe = function() {
         } catch (e) { }
       }
 
-      self.emitter.emit('message', message);
-    }).addCallback(function(ok) {
-      self._ctag = ok.consumerTag;
-    });
+      this.emitter.emit('message', message);
+    }).addCallback((ok) => this._ctag = ok.consumerTag);
   };
 
-  if (self.emitter.isReady) {
-    process.nextTick(subscribeFunc);
+  if (this.emitter.isReady) {
+    setImmediate(subscribeFunc.bind(this));
   } else {
-    self.emitter.once('ready', subscribeFunc);
+    this.emitter.once('ready', subscribeFunc.bind(this));
   }
 };
 
 AmqpProvider.prototype.unsubscribe = function() {
-  const self = this;
-  process.nextTick(function() {
-    self._isClosed = true;
-    self._queue.unsubscribe(self._ctag);
+  setImmediate(() => {
+    this._isClosed = true;
+    this._queue.unsubscribe(this._ctag);
   });
 };
 
@@ -84,35 +75,34 @@ AmqpProvider.prototype.close = function() {
 };
 
 AmqpProvider.prototype._initProvider = function() {
-  const self = this;
   async.series([
 
-    function(cb) {
-      const conn = self._connection = amqp.createConnection(self.options);
-      conn.on('ready', cb);
+    (cb) => {
+      this._connection = amqp.createConnection(this.options);
+      this._connection.on('ready', cb);
     },
 
-    function(cb) {
-      self._connection.exchange(self.options.exchangeName, { type: 'topic' }, function(exchange) {
-        self._exchange = exchange;
+    (cb) => {
+      this._connection.exchange(this.options.exchangeName, { type: 'topic' }, (exchange) => {
+        this._exchange = exchange;
         cb();
       });
     },
 
-    function(cb) {
-      self._connection.queue(self._q, { closeChannelOnUnsubscribe: true }, function(queue) {
-        self._queue = queue;
+    (cb) => {
+      this._connection.queue(this._q, { closeChannelOnUnsubscribe: true }, (queue) => {
+        this._queue = queue;
         cb();
       });
     },
 
-    function(cb) {
-      self._queue.bind(self.options.exchangeName, '#', cb);
+    (cb) => {
+      this._queue.bind(this.options.exchangeName, '#', cb);
     }
 
-  ], function(err) {
-    self.emitter.isReady = true;
-    self.emitter.emit('ready');
+  ], (err) => {
+    this.emitter.isReady = true;
+    this.emitter.emit('ready');
   });
 };
 

--- a/lib/providers/sqs.js
+++ b/lib/providers/sqs.js
@@ -21,92 +21,80 @@ function SqsProvider(emitter, options) {
   this._q = options.queueName;
   this._sqs = new AWS.SQS();
 
-  process.nextTick(this._initProvider.bind(this));
+  setImmediate(() => this._initProvider());
 }
 
 SqsProvider.prototype.publish = function(message) {
-  const self = this;
-  const publishFunc = function() {
-    const messageStr = typeof message !== 'string' ?
-                     message instanceof Buffer ?
-                     message.toString('base64') :
-                     JSON.stringify(message) :
-                     message;
-    self._sendMessage(messageStr);
-  };
+  const messageStr = typeof message !== 'string' ?
+                    message instanceof Buffer ?
+                    message.toString('base64') :
+                    JSON.stringify(message) :
+                    message;
 
-  if (self.emitter.isReady) {
-    process.nextTick(publishFunc);
+  if (this.emitter.isReady) {
+    setImmediate(() => this._sendMessage(messageStr));
   } else {
-    self.emitter.once('ready', publishFunc);
+    this.emitter.once('ready', () => this._sendMessage(messageStr));
   }
 };
 
 SqsProvider.prototype.subscribe = function() {
   if (this.emitter.isReady) {
-    process.nextTick(this._startPolling.bind(this));
+    setImmediate(() => this._startPolling());
   } else {
-    this.emitter.once('ready', this._startPolling.bind(this));
+    this.emitter.once('ready', () => this._startPolling());
   }
 };
 
 SqsProvider.prototype.ack = function(messageId) {
   if (!this.options.deleteAfterReceive) {
-    process.nextTick(this._deleteMessage.bind(this, messageId));
+    setImmediate(() => this._deleteMessage(messageId));
   }
 };
 
 SqsProvider.prototype.unsubscribe = function() {
-  const self = this;
-  process.nextTick(function() {
-    self._isClosed = true;
-  });
+  setImmediate(() => this._isClosed = true);
 };
 
 SqsProvider.prototype._deleteMessage = function(receiptHandle) {
-  const self = this;
-
   const param = {
-    QueueUrl: self._queueUrl,
+    QueueUrl: this._queueUrl,
     ReceiptHandle: receiptHandle
   };
 
-  self._sqs.deleteMessage(param, function(err) {
+  this._sqs.deleteMessage(param, (err) => {
     if (err) {
-      self.emitter.emit('error', err);
+      this.emitter.emit('error', err);
     }
   });
 };
 
 SqsProvider.prototype._initProvider = function() {
-  const self = this;
-  const param = { QueueName: self._q };
+  const param = { QueueName: this._q };
 
-  self._sqs.getQueueUrl(param, function(err, data) {
+  this._sqs.getQueueUrl(param, (err, data) => {
     if (err) {
-      return self._createQueue(err);
+      return this._createQueue(err);
     }
 
-    self._setQueueReady(data.QueueUrl);
+    this._setQueueReady(data.QueueUrl);
   });
 };
 
 SqsProvider.prototype._createQueue = function(getQueueUrlError) {
-  const self = this;
-
   const param = {
-    QueueName: self._q,
-    Attributes: self.options.attributes
+    QueueName: this._q,
+    Attributes: this.options.attributes
   };
 
-  self._sqs.createQueue(param, function(err, data) {
+  this._sqs.createQueue(param, (err, data) => {
     if (err) {
-      self.emitter.emit('error', getQueueUrlError);
-      self.emitter.emit('error', err);
+      this.emitter.emit('error', getQueueUrlError);
+      this.emitter.emit('error', err);
       return;
     }
 
-    self._setQueueReady(data.QueueUrl);
+    this._setQueueReady(data.QueueUrl);
   });
 };
 
@@ -118,29 +106,27 @@ SqsProvider.prototype._setQueueReady = function(queueUrl) {
 };
 
 SqsProvider.prototype._poll = function(done) {
-  const self = this;
-
   const param = {
-    QueueUrl: self._queueUrl,
-    MaxNumberOfMessages: self.options.maxReceiveCount || 1
+    QueueUrl: this._queueUrl,
+    MaxNumberOfMessages: this.options.maxReceiveCount || 1
   };
 
-  if (typeof self.options.visibilityTimeout !== 'undefined') {
-    param.VisibilityTimeout = self.options.visibilityTimeout;
-    param.WaitTimeSeconds = self.options.waitTimeSeconds;
+  if (typeof this.options.visibilityTimeout !== 'undefined') {
+    param.VisibilityTimeout = this.options.visibilityTimeout;
+    param.WaitTimeSeconds = this.options.waitTimeSeconds;
   }
 
-  if (typeof self.options.waitTimeSeconds !== 'undefined') {
-    param.WaitTimeSeconds = self.options.waitTimeSeconds;
+  if (typeof this.options.waitTimeSeconds !== 'undefined') {
+    param.WaitTimeSeconds = this.options.waitTimeSeconds;
   }
 
-  self._sqs.receiveMessage(param, function(err, data) {
+  this._sqs.receiveMessage(param, (err, data) => {
     if (err) {
-      self.emitter.emit('error', err);
+      this.emitter.emit('error', err);
       return void done();
     }
 
-    (data.Messages || []).forEach(function(msg) {
+    (data.Messages || []).forEach((msg) => {
       const isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
       let decoded = msg.Body;
 
@@ -156,9 +142,9 @@ SqsProvider.prototype._poll = function(done) {
         } catch (e) {}
       }
 
-      self.emitter.emit('message', decoded, msg.ReceiptHandle);
-      if (!self._isClosed && self.options.deleteAfterReceive) {
-        self._deleteMessage(msg.ReceiptHandle);
+      this.emitter.emit('message', decoded, msg.ReceiptHandle);
+      if (!this._isClosed && this.options.deleteAfterReceive) {
+        this._deleteMessage(msg.ReceiptHandle);
       }
     });
 
@@ -168,35 +154,30 @@ SqsProvider.prototype._poll = function(done) {
 };
 
 SqsProvider.prototype._sendMessage = function(message) {
-  const self = this;
-
   const param = {
-    QueueUrl: self._queueUrl,
+    QueueUrl: this._queueUrl,
     MessageBody: message
   };
 
-  self._sqs.sendMessage(param, function(err) {
+  this._sqs.sendMessage(param, (err) => {
     if (err) {
-      self.emitter.emit('error', err);
+      this.emitter.emit('error', err);
     }
   });
 };
 
 SqsProvider.prototype._startPolling = function() {
-  const self = this;
-  self._isClosed = false;
+  this._isClosed = false;
 
   async.until(
 
-    function() { return self._isClosed; },
+    () => this._isClosed,
 
-    function(cb) {
-      self._poll(function() {
-        setTimeout(cb, (self.options.delayBetweenPolls || 0) * 1000);
-      });
+    (cb) => {
+      this._poll(() => setTimeout(cb, (this.options.delayBetweenPolls || 0) * 1000));
     },
 
-    Function.prototype // noop - can be removed when async is upgraded
+    noop => noop // noop - can be removed when async is upgraded
 
   );
 

--- a/lib/providers/zmq.js
+++ b/lib/providers/zmq.js
@@ -17,49 +17,40 @@ function ZeroMqProvider(emitter, options) {
   this._pubSock = zmq.socket('pub');
   this._subSock = zmq.socket('sub');
 
-  process.nextTick(this._initProvider.bind(this));
+  setImmediate(() => this._initProvider());
 }
 
 ZeroMqProvider.prototype.publish = function(message) {
-  const self = this;
-
-  const publishFunc = function() {
-    const messageStr = typeof message !== 'string' ?
+  const messageStr = typeof message !== 'string' ?
                      message instanceof Buffer ?
                      message.toString('base64') :
                      JSON.stringify(message) :
                      message;
 
-    self._sendMessage(messageStr);
-  }
-
-  if (self.emitter.isReady) {
-    process.nextTick(publishFunc);
+  if (this.emitter.isReady) {
+    setImmediate(() => this._sendMessage(messageStr));
   } else {
-    self.emitter.once('ready', function() {
-      process.nextTick(publishFunc);
+    this.emitter.once('ready', () => {
+      setImmediate(() => this._sendMessage(messageStr));
     });
   }
 };
 
 ZeroMqProvider.prototype.subscribe = function() {
-  const self = this;
-
-  if (self.emitter.isReady) {
-    process.nextTick(self._connectSubscriber.bind(self));
+  if (this.emitter.isReady) {
+    setImmediate(() => this._connectSubscriber());
   } else {
-    self.emitter.once('ready', function() {
-      process.nextTick(self._connectSubscriber.bind(self));
+    this.emitter.once('ready', () => {
+      setImmediate(() => this._connectSubscriber());
     });
   }
 };
 
 ZeroMqProvider.prototype.unsubscribe = function() {
-  const self = this;
-  process.nextTick(function() {
-    if (!self._isClosed) {
-      self._isClosed = true;
-      self._subSock.disconnect(self._url);
+  setImmediate(() => {
+    if (!this._isClosed) {
+      this._isClosed = true;
+      this._subSock.disconnect(this._url);
     }
   });
 };
@@ -69,57 +60,46 @@ ZeroMqProvider.prototype.close = function() {
 }
 
 ZeroMqProvider.prototype._initProvider = function() {
-  const self = this;
-
-  self._pubSock.bind(self._url, function(err) {
+  this._pubSock.bind(this._url, (err) => {
     if (err) {
-      self.emitter.emit('error', err);
+      this.emitter.emit('error', err);
       return;
     }
 
-    self.emitter.isReady = true;
-    self.emitter.emit('ready');
+    this.emitter.isReady = true;
+    this.emitter.emit('ready');
   });
-
 };
 
 ZeroMqProvider.prototype._connectSubscriber = function() {
-  const self = this;
+  this._subSock.connect(this._url);
+  this._subSock.subscribe(this._q);
 
-  self._subSock.connect(self._url);
-  self._subSock.subscribe(self._q);
-
-  self._subSock.on('message', function(topic, data) {
-    data = data.toString('ascii').replace(new RegExp('^'+self._q+' '), '');
+  this._subSock.on('message', (topic, messageStr) => {
     const isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/gi;
+    let message = messageStr;
 
     // first try to detect if it is a base64 string
     // if so convert to Buffer
-    if (isBase64.test(data)) {
-      data = new Buffer(data, 'base64');
+    if (isBase64.test(messageStr)) {
+      message = new Buffer(messageStr, 'base64');
     } else {
       // next try to decode as json
       // but if it fails just leave as original string
       try {
-        data = JSON.parse(data);
+        message = JSON.parse(messageStr);
       } catch (e) {}
     }
 
-    self.emitter.emit('message', data);
-
+    this.emitter.emit('message', message);
   });
 };
 
 ZeroMqProvider.prototype._sendMessage = function(message) {
-  const self = this;
-
   try {
-    // It is necessary to prepend the queue name to the message
-    // For some reason zeromq thinks that the first word of the
-    // message is the topic name if it matches
-    self._pubSock.send([self._q, self._q + ' ' + message]);
+    this._pubSock.send([this._q, message]);
   } catch (err) {
-    self.emitter.emit('error', err);
+    this.emitter.emit('error', err);
   }
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,7 +23,7 @@ function Queue(options) {
     throw err;
   }
 
-  this.on('newListener', function(event) {
+  this.on('newListener', (event) => {
     if (event !== 'message') return;
 
     // Defer calling `subscribe` until next event loop so that messages
@@ -31,13 +31,11 @@ function Queue(options) {
     // `listeners(event).length will be 0 when the first listener is added
     // because 'newListener' event is called prior to the listener being added
     if (this.listeners(event).length === 0) {
-      process.nextTick(function() {
-        this._provider.subscribe();
-      }.bind(this));
+      setImmediate(() => this._provider.subscribe());
     }
   });
 
-  this.on('removeListener', function(event) {
+  this.on('removeListener', (event) => {
     if (event !== 'message') return;
 
     if (this.listeners(event).length === 0) {

--- a/test/index.js
+++ b/test/index.js
@@ -10,42 +10,42 @@ const mq = proxyquire('../', {
   './lib/queue': QueueStub
 });
 
-tap.beforeEach(function(done) {
+tap.beforeEach((done) => {
   QueueStub.reset();
   done();
 });
 
-tap.test('Main export has function called `connect`', function(t) {
+tap.test('Main export has function called `connect`', (t) => {
   t.type(mq.connect, 'function');
   t.end();
 });
 
-tap.test('Throw an error if no args used', function(t) {
-  t.throws(function() { mq.connect(); }, { message: /url.+not.+set/i });
+tap.test('Throw an error if no args used', (t) => {
+  t.throws(() => mq.connect(), { message: /url.+not.+set/i });
   t.end();
 });
 
-tap.test('Throw an error if url not a string or object', function(t) {
-  t.throws(function() { mq.connect(1); }, { message: /url.+must.+string.+options.+object/i });
+tap.test('Throw an error if url not a string or object', (t) => {
+  t.throws(() => mq.connect(1), { message: /url.+must.+string.+options.+object/i });
   t.end();
 });
 
-tap.test('Throw an error if url string is not in expected format', function(t) {
-  t.throws(function() { mq.connect('invalid url string'); }, { message: /invalid.+url/i });
+tap.test('Throw an error if url string is not in expected format', (t) => {
+  t.throws(() => mq.connect('invalid url string'), { message: /invalid.+url/i });
   t.end();
 });
 
-tap.test('Throw an error if options object does not contain a `provider` property', function(t) {
-  t.throws(function() { mq.connect({}); }, { message: /provider.+missing/i });
+tap.test('Throw an error if options object does not contain a `provider` property', (t) => {
+  t.throws(() => mq.connect({}), { message: /provider.+missing/i });
   t.end();
 });
 
-tap.test('Throw an error if options object does not contain a `queueName` property', function(t) {
-  t.throws(function() { mq.connect({ provider: 'test' }); }, { message: /queueName.+missing/i });
+tap.test('Throw an error if options object does not contain a `queueName` property', (t) => {
+  t.throws(() => mq.connect({ provider: 'test' }), { message: /queueName.+missing/i });
   t.end();
 });
 
-tap.test('Instantiates a new queue', function(t) {
+tap.test('Instantiates a new queue', (t) => {
   const queue = mq.connect('test://queue');
   const expectedOptions = {
     provider: 'test',
@@ -59,7 +59,7 @@ tap.test('Instantiates a new queue', function(t) {
   t.end();
 });
 
-tap.test('Instantiates a new queue when using options object', function(t) {
+tap.test('Instantiates a new queue when using options object', (t) => {
   const options = {
     provider: 'test',
     queueName: 'queue'
@@ -71,7 +71,7 @@ tap.test('Instantiates a new queue when using options object', function(t) {
   t.end();
 });
 
-tap.test('Instantiates a new queue when string URL and options object', function(t) {
+tap.test('Instantiates a new queue when string URL and options object', (t) => {
   const queue = mq.connect('test://queue', { customProperty: 'test' });
   const expectedOptions = {
     provider: 'test',

--- a/test/lib/providers/amqp.js
+++ b/test/lib/providers/amqp.js
@@ -21,7 +21,7 @@ const SubscribePromise = function() { };
 const fakeConsumerTag = 'test123';
 
 
-tap.beforeEach(function(done) {
+tap.beforeEach((done) => {
   amqpStub.createConnection = sinon.stub().returns(new AmqpConnectionStub());
 
   SubscribePromise.prototype.addCallback = sinon.stub().callsArgWith(0, {
@@ -44,45 +44,47 @@ tap.beforeEach(function(done) {
   done();
 });
 
-tap.test('Throws an error if `emitter` arg is not set', function(t) {
-  t.throws(function() { new AmqpProvider(); }, { message: /emitter.+not.+set/i });
+tap.test('Throws an error if `emitter` arg is not set', (t) => {
+  t.throws(() => new AmqpProvider(), { message: /emitter.+not.+set/i });
   t.end();
 });
 
-tap.test('Throws an error if `options` args is not set', function(t) {
-  t.throws(function() { new AmqpProvider({}); }, { message: /options.+not.+set/i });
+tap.test('Throws an error if `options` args is not set', (t) => {
+  t.throws(() => new AmqpProvider({}), { message: /options.+not.+set/i });
   t.end();
 });
 
-tap.test('Throws an error if `options` args is missing `queueName` property', function(t) {
+tap.test('Throws an error if `options` args is missing `queueName` property', (t) => {
   const providerOptions = {};
 
-  t.throws(function() { new AmqpProvider({}, providerOptions); }, { message: /queueName.+not.+set/i });
+  t.throws(() => new AmqpProvider({}, providerOptions), { message: /queueName.+not.+set/i });
   t.end();
 });
 
-tap.test('Throws an error if `options` args is missing `exchangeName` property', function(t) {
+tap.test('Throws an error if `options` args is missing `exchangeName` property', (t) => {
   const providerOptions = {
     queueName: 'queue'
   };
 
-  t.throws(function() { new AmqpProvider({}, providerOptions); }, { message: /exchangeName.+not.+set/i });
+  t.throws(() => new AmqpProvider({}, providerOptions), { message: /exchangeName.+not.+set/i });
   t.end();
 });
 
-tap.test('Does not throw an error if args are valid', function(t) {
+tap.test('Does not throw an error if args are valid', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
   };
 
-  sinon.stub(AmqpProvider.prototype, '_initProvider', function() { });
-  t.doesNotThrow(function() { new AmqpProvider({}, providerOptions); });
-  AmqpProvider.prototype._initProvider.restore();
-  t.end();
+  sinon.stub(AmqpProvider.prototype, '_initProvider', noop => noop);
+  t.doesNotThrow(() => new AmqpProvider({}, providerOptions));
+  setImmediate(() => {
+    AmqpProvider.prototype._initProvider.restore();
+    t.end();
+  });
 });
 
-tap.test('Creates a connection with provider options', function(t) {
+tap.test('Creates a connection with provider options', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -90,14 +92,14 @@ tap.test('Creates a connection with provider options', function(t) {
   const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
-  setTimeout(function() {
+  setImmediate(() => {
     t.ok(amqpStub.createConnection.called);
     t.equal(amqpStub.createConnection.getCall(0).args[0], providerOptions);
     t.end();
-  }, 10);
+  });
 });
 
-tap.test('Creates an exchange using specified name', function(t) {
+tap.test('Creates an exchange using specified name', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -105,19 +107,19 @@ tap.test('Creates an exchange using specified name', function(t) {
   const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
-  setTimeout(function() {
+  setImmediate(() => {
     t.ok(provider._connection);
     provider._connection.emit('ready');
-    setTimeout(function() {
+    setImmediate(() => {
       t.ok(provider._connection.exchange.called);
       t.equal(provider._connection.exchange.getCall(0).args[0], providerOptions.exchangeName);
       t.equal(typeof provider._connection.exchange.getCall(0).args[2], 'function');
       t.end();
-    }, 10);
-  }, 10);
+    });
+  });
 });
 
-tap.test('Creates a queue using specified name', function(t) {
+tap.test('Creates a queue using specified name', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -125,17 +127,17 @@ tap.test('Creates a queue using specified name', function(t) {
   const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
-  setTimeout(function() {
+  setImmediate(() => {
     provider._connection.emit('ready');
-    setTimeout(function() {
+    setImmediate(() => {
       t.equal(provider._connection.queue.getCall(0).args[0], providerOptions.queueName);
       t.equal(typeof provider._connection.queue.getCall(0).args[2], 'function');
       t.end();
-    }, 10);
-  }, 10);
+    });
+  });
 });
 
-tap.test('Binds the queue to the exchange', function(t) {
+tap.test('Binds the queue to the exchange', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -143,18 +145,18 @@ tap.test('Binds the queue to the exchange', function(t) {
   const provider = new AmqpProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
-  setTimeout(function() {
+  setImmediate(() => {
     provider._connection.emit('ready');
-    setTimeout(function() {
+    setImmediate(() => {
       t.ok(provider._queue);
       t.equal(provider._queue.bind.getCall(0).args[0], providerOptions.exchangeName);
       t.equal(provider._queue.bind.getCall(0).args[1], '#');
       t.end();
-    }, 10);
-  }, 10);
+    });
+  });
 });
 
-tap.test('Sets emmitter to ready', function(t) {
+tap.test('Sets emmitter to ready', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -163,15 +165,15 @@ tap.test('Sets emmitter to ready', function(t) {
   const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     t.equal(emitter.isReady, true);
     t.end();
   });
 });
 
-tap.test('Calls publish function with string message', function(t) {
+tap.test('Calls publish function with string message', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -183,19 +185,19 @@ tap.test('Calls publish function with string message', function(t) {
   provider.publish(message);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       t.ok(provider._exchange.publish.called);
       t.equal(provider._exchange.publish.getCall(0).args[0], providerOptions.queueName);
       t.equal(provider._exchange.publish.getCall(0).args[1], message);
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Calls publish function with JSON string', function(t) {
+tap.test('Calls publish function with JSON string', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -207,19 +209,19 @@ tap.test('Calls publish function with JSON string', function(t) {
   provider.publish(message);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       t.ok(provider._exchange.publish.called);
       t.equal(provider._exchange.publish.getCall(0).args[0], providerOptions.queueName);
       t.equal(provider._exchange.publish.getCall(0).args[1], JSON.stringify(message));
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Calls publish function with Buffer', function(t) {
+tap.test('Calls publish function with Buffer', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -231,19 +233,19 @@ tap.test('Calls publish function with Buffer', function(t) {
   provider.publish(message);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       t.ok(provider._exchange.publish.called);
       t.equal(provider._exchange.publish.getCall(0).args[0], providerOptions.queueName);
       t.equal(provider._exchange.publish.getCall(0).args[1], message.toString('base64'));
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Calls publish function when already... "ready"', function(t) {
+tap.test('Calls publish function when already... "ready"', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -253,20 +255,20 @@ tap.test('Calls publish function when already... "ready"', function(t) {
   const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     provider.publish(message);
-    setTimeout(function() {
+    setImmediate(() => {
       t.ok(provider._exchange.publish.called);
       t.equal(provider._exchange.publish.getCall(0).args[0], providerOptions.queueName);
       t.equal(provider._exchange.publish.getCall(0).args[1], message);
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('Subscribes to the queue with a listener', function(t) {
+tap.test('Subscribes to the queue with a listener', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -276,19 +278,19 @@ tap.test('Subscribes to the queue with a listener', function(t) {
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       t.ok(provider._queue.subscribe.called);
       t.equal(provider._ctag, fakeConsumerTag);
       t.equal(typeof provider._queue.subscribe.getCall(0).args[0], 'function');
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Emits a string message event after subscribing', function(t) {
+tap.test('Emits a string message event after subscribing', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -298,23 +300,23 @@ tap.test('Emits a string message event after subscribing', function(t) {
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       const handler = provider._queue.subscribe.getCall(0).args[0];
       const originalMessage = 'test message';
-      emitter.on('message', function(message) {
+      emitter.on('message', (message) => {
         t.equal(message, originalMessage);
         t.end();
       });
 
       handler({ data: originalMessage });
-    }, 20);
+    });
   });
 });
 
-tap.test('Emits an object message event after subscribing', function(t) {
+tap.test('Emits an object message event after subscribing', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -324,23 +326,23 @@ tap.test('Emits an object message event after subscribing', function(t) {
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       const handler = provider._queue.subscribe.getCall(0).args[0];
       const originalMessage = { test: 'test', foo: 'bar' };
-      emitter.on('message', function(message) {
+      emitter.on('message', (message) => {
         t.same(message, originalMessage);
         t.end();
       });
 
       handler({ data: JSON.stringify(originalMessage) });
-    }, 20);
+    });
   });
 });
 
-tap.test('Emits a Buffer message event after subscribing', function(t) {
+tap.test('Emits a Buffer message event after subscribing', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -350,23 +352,23 @@ tap.test('Emits a Buffer message event after subscribing', function(t) {
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       const handler = provider._queue.subscribe.getCall(0).args[0];
       const originalMessage = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-      emitter.on('message', function(message) {
+      emitter.on('message', (message) => {
         t.same(message, originalMessage);
         t.end();
       });
 
       handler({ data: originalMessage.toString('base64') });
-    }, 20);
+    });
   });
 });
 
-tap.test('Subcribes to the queue with a listener when already... "ready"', function(t) {
+tap.test('Subcribes to the queue with a listener when already... "ready"', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -375,19 +377,19 @@ tap.test('Subcribes to the queue with a listener when already... "ready"', funct
   const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     provider.subscribe();
-    setTimeout(function() {
+    setImmediate(() => {
       t.ok(provider._queue.subscribe.called);
       t.equal(typeof provider._queue.subscribe.getCall(0).args[0], 'function');
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Unsubscribes from the queue the queue', function(t) {
+tap.test('Unsubscribes from the queue the queue', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -397,21 +399,21 @@ tap.test('Unsubscribes from the queue the queue', function(t) {
   provider.subscribe();
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       provider.unsubscribe();
-      setTimeout(function() {
+      setImmediate(() => {
         t.ok(provider._queue.unsubscribe.called);
         t.equal(provider._queue.unsubscribe.firstCall.args[0], fakeConsumerTag);
         t.end();
-      }, 10);
-    }, 10);
+      });
+    });
   });
 });
 
-tap.test('Unbinds from the queue on close', function(t) {
+tap.test('Unbinds from the queue on close', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -420,20 +422,20 @@ tap.test('Unbinds from the queue on close', function(t) {
   const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       provider.close();
       t.ok(provider._queue.unbind.called);
       t.equal(provider._queue.unbind.firstCall.args[0], provider._exchange);
       t.equal(provider._queue.unbind.firstCall.args[1], '#');
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('Destroys the exchange and queue on close', function(t) {
+tap.test('Destroys the exchange and queue on close', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -442,19 +444,19 @@ tap.test('Destroys the exchange and queue on close', function(t) {
   const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       provider.close();
       t.ok(provider._queue.destroy.called);
       t.ok(provider._exchange.destroy.called);
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('Disconnects the connection on close', function(t) {
+tap.test('Disconnects the connection on close', (t) => {
   const providerOptions = {
     queueName: 'queue',
     exchangeName: 'exchange'
@@ -463,13 +465,13 @@ tap.test('Disconnects the connection on close', function(t) {
   const provider = new AmqpProvider(emitter, providerOptions);
 
   // Defer this emit since provider is initialized on next event loop
-  setTimeout(function() { provider._connection.emit('ready'); }, 10);
+  setImmediate(() => provider._connection.emit('ready'));
 
-  emitter.once('ready', function() {
-    setTimeout(function() {
+  emitter.once('ready', () => {
+    setImmediate(() => {
       provider.close();
       t.ok(provider._connection.disconnect.called);
       t.end();
-    }, 10);
+    });
   });
 });

--- a/test/lib/providers/sqs.js
+++ b/test/lib/providers/sqs.js
@@ -19,7 +19,7 @@ const SqsProvider = proxyquire('../../../lib/providers/sqs', {
 
 const fakeQueueUrl = 'https://fake.sqs.url/test';
 
-tap.beforeEach(function(done) {
+tap.beforeEach((done) => {
   AWSStub.SQS = sinon.stub();
   AWSStub.config = {
     loadFromPath: sinon.stub(),
@@ -39,103 +39,111 @@ tap.beforeEach(function(done) {
   done();
 });
 
-tap.test('Throws an error if `emitter` arg is not set', function(t) {
-  t.throws(function() { new SqsProvider(); }, { message: /emitter.+not.+set/i });
+tap.test('Throws an error if `emitter` arg is not set', (t) => {
+  t.throws(() => new SqsProvider(), { message: /emitter.+not.+set/i });
   t.end();
 });
 
-tap.test('Throws an error if `options` args is not set', function(t) {
-  t.throws(function() { new SqsProvider({}); }, { message: /options.+not.+set/i });
+tap.test('Throws an error if `options` args is not set', (t) => {
+  t.throws(() => new SqsProvider({}), { message: /options.+not.+set/i });
   t.end();
 });
 
-tap.test('Throws an error if `options` args is missing `queueName` property', function(t) {
+tap.test('Throws an error if `options` args is missing `queueName` property', (t) => {
   const providerOptions = {};
 
-  t.throws(function() { new SqsProvider({}, providerOptions); }, { message: /queueName.+not.+set/i });
+  t.throws(() => new SqsProvider({}, providerOptions), { message: /queueName.+not.+set/i });
   t.end();
 });
 
-tap.test('Does not throw an error if args are valid', function(t) {
+tap.test('Does not throw an error if args are valid', (t) => {
   const providerOptions = { queueName: 'queue' };
 
-  sinon.stub(SqsProvider.prototype, '_initProvider', function() { });
-  t.doesNotThrow(function() { new SqsProvider({}, providerOptions); });
-  SqsProvider.prototype._initProvider.restore();
-  t.end();
+  sinon.stub(SqsProvider.prototype, '_initProvider', noop => noop);
+  t.doesNotThrow(() => new SqsProvider({}, providerOptions));
+  setImmediate(() => {
+    SqsProvider.prototype._initProvider.restore();
+    t.end();
+  });
 });
 
-tap.test('Loads AWS config from a file if `awsConfig` is a string', function(t) {
+tap.test('Loads AWS config from a file if `awsConfig` is a string', (t) => {
   const providerOptions =
   {
     queueName: 'queue',
     awsConfig: '/a/fake/aws/config'
   };
 
-  sinon.stub(SqsProvider.prototype, '_initProvider', function() { });
+  sinon.stub(SqsProvider.prototype, '_initProvider', noop => noop);
   new SqsProvider({}, providerOptions);
   t.ok(AWSStub.config.loadFromPath.called, '`loadFromPath` method not called.');
   t.equal(AWSStub.config.loadFromPath.getCall(0).args[0], providerOptions.awsConfig);
-  SqsProvider.prototype._initProvider.restore();
-  t.end();
+  setImmediate(() => {
+    SqsProvider.prototype._initProvider.restore();
+    t.end();
+  });
 });
 
-tap.test('Update AWS config from `awsConfig` object when set', function(t) {
+tap.test('Update AWS config from `awsConfig` object when set', (t) => {
   const providerOptions =
   {
     queueName: 'queue',
     awsConfig: { some: 'aws', config: true }
   };
 
-  sinon.stub(SqsProvider.prototype, '_initProvider', function() { });
+  sinon.stub(SqsProvider.prototype, '_initProvider', noop => noop);
   new SqsProvider({}, providerOptions);
   t.ok(AWSStub.config.update.called, '`update` method not called.');
   t.equal(AWSStub.config.update.getCall(0).args[0], providerOptions.awsConfig);
-  SqsProvider.prototype._initProvider.restore();
-  t.end();
+  setImmediate(() => {
+    SqsProvider.prototype._initProvider.restore();
+    t.end();
+  });
 });
 
-tap.test('Instantiates a new `AWS.SQS` object', function(t) {
+tap.test('Instantiates a new `AWS.SQS` object', (t) => {
   const providerOptions = { queueName: 'queue' };
 
-  sinon.stub(SqsProvider.prototype, '_initProvider', function() { });
+  sinon.stub(SqsProvider.prototype, '_initProvider', noop => noop);
   const provider = new SqsProvider({}, providerOptions);
   t.ok(AWSStub.SQS.calledWithNew(), '`AWS.SQS` object was not instantiated.');
   t.type(provider._sqs, AWSStub.SQS);
-  SqsProvider.prototype._initProvider.restore();
-  t.end();
+  setImmediate(() => {
+    SqsProvider.prototype._initProvider.restore();
+    t.end();
+  });
 });
 
-tap.test('Gets the QueueUrl on provider init', function(t) {
+tap.test('Gets the QueueUrl on provider init', (t) => {
   const providerOptions = { queueName: 'queue' };
   const provider = new SqsProvider(new EventEmitter(), providerOptions);
 
   // Defer these tests since provider is initialized on next event loop
-  setTimeout(function() {
+  setImmediate(() => {
     const expectedParams = { QueueName: providerOptions.queueName };
     t.ok(provider._sqs.getQueueUrl.called);
     t.same(provider._sqs.getQueueUrl.getCall(0).args[0], expectedParams);
     t.equal(typeof provider._sqs.getQueueUrl.getCall(0).args[1], 'function');
     t.end();
-  }, 20);
+  });
 });
 
-tap.test('Creates the queue on provider init if error callback from SQS `getQueueUrl`', function(t) {
+tap.test('Creates the queue on provider init if error callback from SQS `getQueueUrl`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const provider = new SqsProvider(new EventEmitter(), providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
 
   // Defer these tests since provider is initialized on next event loop
-  setTimeout(function() {
+  setImmediate(() => {
     const expectedParams = { QueueName: providerOptions.queueName };
     t.ok(provider._sqs.createQueue.called);
     t.match(provider._sqs.createQueue.getCall(0).args[0], expectedParams);
     t.equal(typeof provider._sqs.createQueue.getCall(0).args[1], 'function');
     t.end();
-  }, 10);
+  });
 });
 
-tap.test('Creates or retrieves a QueueUrl on provider init (with attributes)', function(t) {
+tap.test('Creates or retrieves a QueueUrl on provider init (with attributes)', (t) => {
   const providerOptions = {
     queueName: 'queue',
     attributes: { custom: 'attributes' }
@@ -144,53 +152,53 @@ tap.test('Creates or retrieves a QueueUrl on provider init (with attributes)', f
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
 
   // Defer these tests since provider is initialized on next event loop
-  setTimeout(function() {
+  setImmediate(() => {
     const expectedParams = {
       QueueName: providerOptions.queueName,
       Attributes: providerOptions.attributes
     };
     t.match(provider._sqs.createQueue.getCall(0).args[0], expectedParams);
     t.end();
-  }, 10);
+  });
 });
 
-tap.test('Emits "ready" event on call back from `getQueueUrl`', function(t) {
+tap.test('Emits "ready" event on call back from `getQueueUrl`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
 
-  emitter.on('ready', function() {
+  emitter.on('ready', () => {
     t.ok(emitter.isReady);
     t.end();
   });
 });
 
-tap.test('Emits "ready" event on call back from `createQueue`', function(t) {
+tap.test('Emits "ready" event on call back from `createQueue`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
 
-  emitter.on('ready', function() {
+  emitter.on('ready', () => {
     t.ok(emitter.isReady);
     t.end();
   });
 });
 
-tap.test('Sets `_queueUrl` property with value called back from `getQueueUrl`', function(t) {
+tap.test('Sets `_queueUrl` property with value called back from `getQueueUrl`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const queueData = { QueueUrl: 'https://fake.sqs.url/test' };
   const provider = new SqsProvider(emitter, providerOptions);
   provider._sqs.getQueueUrl.callsArgWith(1, null, queueData);
 
-  emitter.on('ready', function() {
+  emitter.on('ready', () => {
     t.equal(provider._queueUrl, queueData.QueueUrl);
     t.end();
   });
 });
 
-tap.test('Sets `_queueUrl` property with value called back from `createQueue`', function(t) {
+tap.test('Sets `_queueUrl` property with value called back from `createQueue`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const queueData = { QueueUrl: 'https://fake.sqs.url/test' };
@@ -198,13 +206,13 @@ tap.test('Sets `_queueUrl` property with value called back from `createQueue`', 
   provider._sqs.getQueueUrl.callsArgWith(1, new Error('getQueueUrl error'));
   provider._sqs.createQueue.callsArgWith(1, null, queueData);
 
-  emitter.on('ready', function() {
+  emitter.on('ready', () => {
     t.equal(provider._queueUrl, queueData.QueueUrl);
     t.end();
   });
 });
 
-tap.test('Emits "error" event twice if error called back from `createQueue`', function(t) {
+tap.test('Emits "error" event twice if error called back from `createQueue`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const getQueueUrlError = new Error('getQueueUrl error');
@@ -213,8 +221,8 @@ tap.test('Emits "error" event twice if error called back from `createQueue`', fu
   provider._sqs.getQueueUrl.callsArgWith(1, getQueueUrlError);
   provider._sqs.createQueue.callsArgWith(1, createError);
 
-  emitter.once('error', function(err1) {
-    emitter.once('error', function(err2) {
+  emitter.once('error', (err1) => {
+    emitter.once('error', (err2) => {
       t.equal(err1, getQueueUrlError);
       t.equal(err2, createError);
       t.end();
@@ -222,7 +230,7 @@ tap.test('Emits "error" event twice if error called back from `createQueue`', fu
   });
 });
 
-tap.test('Calls publish function with string message', function(t) {
+tap.test('Calls publish function with string message', (t) => {
   const providerOptions = { queueName: 'queue' };
   const message = 'test message';
   const emitter = new EventEmitter();
@@ -230,9 +238,9 @@ tap.test('Calls publish function with string message', function(t) {
 
   provider.publish(message);
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     // Defer this test to wait for all deferred methods in provider to run
-    setTimeout(function() {
+    setImmediate(() => {
       const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: message
@@ -242,11 +250,11 @@ tap.test('Calls publish function with string message', function(t) {
       t.same(provider._sqs.sendMessage.getCall(0).args[0], expectedParams);
       t.equal(typeof provider._sqs.sendMessage.getCall(0).args[1], 'function');
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Calls publish function with JSON string', function(t) {
+tap.test('Calls publish function with JSON string', (t) => {
   const providerOptions = { queueName: 'queue' };
   const message = { test: 'obj', foo: 'bar' };
   const emitter = new EventEmitter();
@@ -254,9 +262,9 @@ tap.test('Calls publish function with JSON string', function(t) {
 
   provider.publish(message);
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     // Defer this test to wait for all deferred methods in provider to run
-    setTimeout(function() {
+    setImmediate(() => {
       const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: JSON.stringify(message)
@@ -265,11 +273,11 @@ tap.test('Calls publish function with JSON string', function(t) {
       t.ok(provider._sqs.sendMessage.called);
       t.same(provider._sqs.sendMessage.getCall(0).args[0], expectedParams);
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Calls publish function with Buffer', function(t) {
+tap.test('Calls publish function with Buffer', (t) => {
   const providerOptions = { queueName: 'queue' };
   const message = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   const emitter = new EventEmitter();
@@ -277,9 +285,9 @@ tap.test('Calls publish function with Buffer', function(t) {
 
   provider.publish(message);
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     // Defer this test to wait for all deferred methods in provider to run
-    setTimeout(function() {
+    setImmediate(() => {
       const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: message.toString('base64')
@@ -288,19 +296,19 @@ tap.test('Calls publish function with Buffer', function(t) {
       t.ok(provider._sqs.sendMessage.called);
       t.same(provider._sqs.sendMessage.getCall(0).args[0], expectedParams);
       t.end();
-    }, 20);
+    });
   });
 });
 
-tap.test('Calls publish function when already... "ready"', function(t) {
+tap.test('Calls publish function when already... "ready"', (t) => {
   const providerOptions = { queueName: 'queue' };
   const message = 'test message';
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     provider.publish(message);
-    setTimeout(function() {
+    setImmediate(() => {
       const expectedParams = {
         QueueUrl: provider._queueUrl,
         MessageBody: message
@@ -309,11 +317,11 @@ tap.test('Calls publish function when already... "ready"', function(t) {
       t.ok(provider._sqs.sendMessage.called);
       t.same(provider._sqs.sendMessage.getCall(0).args[0], expectedParams);
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('Emits "error" event if error called back from `sendMessage`', function(t) {
+tap.test('Emits "error" event if error called back from `sendMessage`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const expectedError = new Error('Test error');
@@ -322,13 +330,13 @@ tap.test('Emits "error" event if error called back from `sendMessage`', function
 
   provider.publish('test message');
 
-  emitter.on('error', function(err) {
+  emitter.on('error', (err) => {
     t.equal(err, expectedError);
     t.end();
   });
 });
 
-tap.test('Starts polling if subscribing before ready event', function(t) {
+tap.test('Starts polling if subscribing before ready event', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
@@ -336,30 +344,30 @@ tap.test('Starts polling if subscribing before ready event', function(t) {
 
   provider.subscribe();
 
-  emitter.once('ready', function(err) {
-    setTimeout(function() {
+  emitter.once('ready', (err) => {
+    setImmediate(() => {
       t.ok(provider._startPolling.called, '`_startPolling` was not called');
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('Starts polling if subscribing after ready event', function(t) {
+tap.test('Starts polling if subscribing after ready event', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
   provider._startPolling = sinon.stub();
 
-  emitter.once('ready', function(err) {
+  emitter.once('ready', (err) => {
     provider.subscribe();
-    setTimeout(function() {
+    setImmediate(() => {
       t.ok(provider._startPolling.called, '`_startPolling` was not called');
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('Sets `_isClosed` property to true on unsubscribe', function(t) {
+tap.test('Sets `_isClosed` property to true on unsubscribe', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
@@ -367,48 +375,44 @@ tap.test('Sets `_isClosed` property to true on unsubscribe', function(t) {
   t.notOk(provider._isClosed);
   provider.unsubscribe();
 
-  setTimeout(function() {
+  setImmediate(() => {
     t.ok(provider._isClosed);
     t.end();
-  }, 10);
+  });
 });
 
 if (process.platform === 'win32') {
   skip = 'since timing this test uses is not reliable on windows';
 }
 
-tap.test('`_poll` method is called repeatedly until unsubscribed', { skip: skip }, function(t) {
+tap.test('`_poll` method is called repeatedly until unsubscribed', { skip: skip }, (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
-  sinon.stub(provider, '_poll', function(cb) {
-    setTimeout(cb, 10);
-  });
+  sinon.stub(provider, '_poll', (cb) => setTimeout(cb, 10));
 
   provider._startPolling();
-  setTimeout(function() {
+  setTimeout(() => {
     provider.unsubscribe();
 
     // Expect based on the timeouts given, we expect `_poll` to be called at least 3 times.
     t.ok(provider._poll.getCall(2), '`_poll` was not called the expected number of times');
     t.end();
 
-  }, 50);
+  }, 200);
 });
 
-tap.test('`_poll` method is called with delay as set in options', { skip: skip }, function(t) {
+tap.test('`_poll` method is called with delay as set in options', { skip: skip }, (t) => {
   const providerOptions = {
     queueName: 'queue',
     delayBetweenPolls: 0.01 // 10 milliseconds
   };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
-  sinon.stub(provider, '_poll', function(cb) {
-    setTimeout(cb, 10);
-  });
+  sinon.stub(provider, '_poll', (cb) => setTimeout(cb, 10));
 
   provider._startPolling();
-  setTimeout(function() {
+  setTimeout(() => {
     provider.unsubscribe();
 
     // Expect based on the timeouts and `delayBetweenPolls` given,
@@ -419,13 +423,13 @@ tap.test('`_poll` method is called with delay as set in options', { skip: skip }
   }, 30);
 });
 
-tap.test('`_poll` calls the SQS `_receiveMessage` with default params', function(t) {
+tap.test('`_poll` calls the SQS `_receiveMessage` with default params', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
 
-  emitter.once('ready', function() {
-    provider._poll(function() {
+  emitter.once('ready', () => {
+    provider._poll(() => {
       const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 1
@@ -437,7 +441,7 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with default params', function
   });
 });
 
-tap.test('`_poll` calls the SQS `_receiveMessage` with max number of messages set', function(t) {
+tap.test('`_poll` calls the SQS `_receiveMessage` with max number of messages set', (t) => {
   const providerOptions = {
     queueName: 'queue',
     maxReceiveCount: 10
@@ -445,8 +449,8 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with max number of messages se
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
 
-  emitter.once('ready', function() {
-    provider._poll(function() {
+  emitter.once('ready', () => {
+    provider._poll(() => {
       const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 10
@@ -457,7 +461,7 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with max number of messages se
   });
 });
 
-tap.test('`_poll` calls the SQS `_receiveMessage` with custom visibility timeout set', function(t) {
+tap.test('`_poll` calls the SQS `_receiveMessage` with custom visibility timeout set', (t) => {
   const providerOptions = {
     queueName: 'queue',
     visibilityTimeout: 10
@@ -465,8 +469,8 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with custom visibility timeout
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
 
-  emitter.once('ready', function() {
-    provider._poll(function() {
+  emitter.once('ready', () => {
+    provider._poll(() => {
       const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 1,
@@ -479,7 +483,7 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with custom visibility timeout
   });
 });
 
-tap.test('`_poll` calls the SQS `_receiveMessage` with custom wait time seconds set', function(t) {
+tap.test('`_poll` calls the SQS `_receiveMessage` with custom wait time seconds set', (t) => {
   const providerOptions = {
     queueName: 'queue',
     waitTimeSeconds: 10
@@ -487,8 +491,8 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with custom wait time seconds 
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
 
-  emitter.once('ready', function() {
-    provider._poll(function() {
+  emitter.once('ready', () => {
+    provider._poll(() => {
       const expectedParams = {
         QueueUrl: fakeQueueUrl,
         MaxNumberOfMessages: 1,
@@ -500,40 +504,34 @@ tap.test('`_poll` calls the SQS `_receiveMessage` with custom wait time seconds 
   });
 });
 
-tap.test('`_poll` does not emit a "message" event if no messages returned from SQS `_receiveMessage`', function(t) {
+tap.test('`_poll` does not emit a "message" event if no messages returned from SQS `_receiveMessage`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
 
-  emitter.once('message', function() {
-    t.fail('"message" event should not be called');
-  });
+  emitter.once('message', () => t.fail('"message" event should not be called'));
 
-  emitter.once('ready', function() {
-    provider._poll(function() {
-      t.end();
-    });
+  emitter.once('ready', () => {
+    provider._poll(() => t.end());
   });
 });
 
-tap.test('`_poll` emits error on SQS `_receiveMessage` callback error', function(t) {
+tap.test('`_poll` emits error on SQS `_receiveMessage` callback error', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
   const testError = new Error('Test error');
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, testError);
 
-  setTimeout(function() {
-    provider._poll(Function.prototype);
-  }, 10);
+  setTimeout(() => provider._poll(Function.prototype), 10);
 
-  emitter.once('error', function(err) {
+  emitter.once('error', (err) => {
     t.equal(err, testError);
     t.end();
   });
 });
 
-tap.test('`_poll` emits a string message event', function(t) {
+tap.test('`_poll` emits a string message event', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
@@ -542,18 +540,16 @@ tap.test('`_poll` emits a string message event', function(t) {
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
 
-  emitter.once('message', function(msg, handle) {
+  emitter.once('message', (msg, handle) => {
     t.equal(msg, data.Messages[0].Body);
     t.equal(handle, data.Messages[0].ReceiptHandle);
     t.end();
   });
 
-  emitter.once('ready', function() {
-    provider._poll(Function.prototype);
-  });
+  emitter.once('ready', () => provider._poll(noop => noop));
 });
 
-tap.test('`_poll` emits an object message event', function(t) {
+tap.test('`_poll` emits an object message event', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
@@ -563,18 +559,16 @@ tap.test('`_poll` emits an object message event', function(t) {
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
 
-  emitter.once('message', function(msg, handle) {
+  emitter.once('message', (msg, handle) => {
     t.same(msg, message);
     t.equal(handle, data.Messages[0].ReceiptHandle);
     t.end();
   });
 
-  emitter.once('ready', function() {
-    provider._poll(Function.prototype);
-  });
+  emitter.once('ready', () => provider._poll(noop => noop));
 });
 
-tap.test('`_poll` emits a Buffer message event', function(t) {
+tap.test('`_poll` emits a Buffer message event', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
@@ -584,18 +578,16 @@ tap.test('`_poll` emits a Buffer message event', function(t) {
   };
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
 
-  emitter.once('message', function(msg, handle) {
+  emitter.once('message', (msg, handle) => {
     t.same(msg, message);
     t.equal(handle, data.Messages[0].ReceiptHandle);
     t.end();
   });
 
-  emitter.once('ready', function() {
-    provider._poll(Function.prototype);
-  });
+  emitter.once('ready', () => provider._poll(noop => noop));
 });
 
-tap.test('Calls `_deleteMessage` if `deleteAfterReceive` is true', function(t) {
+tap.test('Calls `_deleteMessage` if `deleteAfterReceive` is true', (t) => {
   const providerOptions = {
     queueName: 'queue',
     deleteAfterReceive: true
@@ -609,8 +601,8 @@ tap.test('Calls `_deleteMessage` if `deleteAfterReceive` is true', function(t) {
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
   provider._deleteMessage = sinon.stub();
 
-  emitter.once('ready', function() {
-    provider._poll(function() {
+  emitter.once('ready', () => {
+    provider._poll(() => {
       t.ok(provider._deleteMessage.called, '`_deleteMessage` method not called');
       t.equal(provider._deleteMessage.getCall(0).args[0], data.Messages[0].ReceiptHandle);
       t.end();
@@ -618,7 +610,7 @@ tap.test('Calls `_deleteMessage` if `deleteAfterReceive` is true', function(t) {
   });
 });
 
-tap.test('Does not call `_deleteMessage` if already unsubscribed', function(t) {
+tap.test('Does not call `_deleteMessage` if already unsubscribed', (t) => {
   const providerOptions = {
     queueName: 'queue',
     deleteAfterReceive: true
@@ -632,35 +624,35 @@ tap.test('Does not call `_deleteMessage` if already unsubscribed', function(t) {
   provider._sqs.receiveMessage = sinon.stub().callsArgWith(1, null, data);
   provider._deleteMessage = sinon.stub();
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     provider.unsubscribe();
-    setTimeout(function() {
-      provider._poll(function() {
+    setImmediate(() => {
+      provider._poll(() => {
         t.notOk(provider._deleteMessage.called, '`_deleteMessage` method should not have been called');
         t.end();
       });
-    }, 10);
+    });
   });
 });
 
-tap.test('`ack` calls `_deleteMessage`', function(t) {
+tap.test('`ack` calls `_deleteMessage`', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
   const messageId = 'test';
   provider._deleteMessage = sinon.stub();
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     provider.ack(messageId);
-    setTimeout(function() {
+    setImmediate(() => {
       t.ok(provider._deleteMessage.called, '`_deleteMessage` method should have been called');
       t.equal(provider._deleteMessage.getCall(0).args[0], messageId);
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('Ignores `ack` if `deleteAfterReceive` is set to true', function(t) {
+tap.test('Ignores `ack` if `deleteAfterReceive` is set to true', (t) => {
   const providerOptions = {
     queueName: 'queue',
     deleteAfterReceive: true
@@ -669,16 +661,16 @@ tap.test('Ignores `ack` if `deleteAfterReceive` is set to true', function(t) {
   const provider = new SqsProvider(emitter, providerOptions);
   provider._deleteMessage = sinon.stub();
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     provider.ack('test');
-    setTimeout(function() {
+    setImmediate(() => {
       t.notOk(provider._deleteMessage.called, '`_deleteMessage` method should not have been called');
       t.end();
-    }, 10);
+    });
   });
 });
 
-tap.test('`_deleteMessage` calls the SQS `deleteMessage` method', function(t) {
+tap.test('`_deleteMessage` calls the SQS `deleteMessage` method', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
@@ -687,7 +679,7 @@ tap.test('`_deleteMessage` calls the SQS `deleteMessage` method', function(t) {
     ReceiptHandle: 'test'
   };
 
-  emitter.once('ready', function() {
+  emitter.once('ready', () => {
     provider._deleteMessage(expectedParams.ReceiptHandle);
 
     t.ok(provider._sqs.deleteMessage.called, 'SQS `deleteMessage` method should have been called');
@@ -696,19 +688,17 @@ tap.test('`_deleteMessage` calls the SQS `deleteMessage` method', function(t) {
   });
 });
 
-tap.test('Emits "error" event if SQS `deleteMessage` calls back an error', function(t) {
+tap.test('Emits "error" event if SQS `deleteMessage` calls back an error', (t) => {
   const providerOptions = { queueName: 'queue' };
   const emitter = new EventEmitter();
   const provider = new SqsProvider(emitter, providerOptions);
   const testError = new Error('test error');
   provider._sqs.deleteMessage = sinon.stub().callsArgWith(1, testError);
 
-  emitter.once('error', function(err) {
+  emitter.once('error', (err) => {
     t.equal(err, testError);
     t.end();
   });
 
-  emitter.once('ready', function() {
-    provider._deleteMessage('test');
-  });
+  emitter.once('ready', () => provider._deleteMessage('test'));
 });

--- a/test/lib/queue.js
+++ b/test/lib/queue.js
@@ -15,14 +15,14 @@ const Queue = proxyquire('../../lib/queue', {
   './providers/zmq': ZmqStub
 });
 
-tap.beforeEach(function(done) {
+tap.beforeEach((done) => {
   AmqpStub.reset();
   SqsStub.reset();
   ZmqStub.reset();
   done();
 });
 
-tap.test('Instantiates a new AMQP Provider', function(t) {
+tap.test('Instantiates a new AMQP Provider', (t) => {
   const options = { provider: 'amqp' };
   const q = new Queue(options);
 
@@ -32,7 +32,7 @@ tap.test('Instantiates a new AMQP Provider', function(t) {
   t.end();
 });
 
-tap.test('Instantiates a new SQS Provider', function(t) {
+tap.test('Instantiates a new SQS Provider', (t) => {
   const options = { provider: 'sqs' };
   const q = new Queue(options);
 
@@ -42,7 +42,7 @@ tap.test('Instantiates a new SQS Provider', function(t) {
   t.end();
 });
 
-tap.test('Instantiates a new ZeroMQ Provider', function(t) {
+tap.test('Instantiates a new ZeroMQ Provider', (t) => {
   const options = { provider: 'zmq' };
   const q = new Queue(options);
 
@@ -52,58 +52,58 @@ tap.test('Instantiates a new ZeroMQ Provider', function(t) {
   t.end();
 });
 
-tap.test('Throws an error if provider not specified', function(t) {
+tap.test('Throws an error if provider not specified', (t) => {
   const expectedError = {
     message: /unable.+instantiate.+provider/i,
     provider: 'invalid',
     inner: {}
   };
 
-  t.throws(function () { new Queue({ provider: 'invalid' }) }, expectedError);
+  t.throws(() => new Queue({ provider: 'invalid' }), expectedError);
   t.end();
 });
 
-tap.test('Queue is an EventEmitter', function(t) {
+tap.test('Queue is an EventEmitter', (t) => {
   const q = new Queue({ provider: 'amqp' });
   t.type(q, EventEmitter);
   t.end();
 });
 
-tap.test('Queue is an EventEmitter', function(t) {
+tap.test('Queue is an EventEmitter', (t) => {
   const q = new Queue({ provider: 'amqp' });
   t.type(q, EventEmitter);
   t.end();
 });
 
-tap.test('Sets `isReady` property to `false`', function(t) {
+tap.test('Sets `isReady` property to `false`', (t) => {
   const q = new Queue({ provider: 'amqp' });
   t.equal(q.isReady, false);
   t.end();
 });
 
-tap.test('Calls provider `subscribe` method once when first listener is added', function(t) {
+tap.test('Calls provider `subscribe` method once when first listener is added', (t) => {
   const q = new Queue({ provider: 'amqp' });
   q._provider.subscribe = sinon.stub();
-  q.on('message', function() { });
-  q.on('message', function() { });
+  q.on('message', noop => noop);
+  q.on('message', noop => noop);
 
   // Defer this until next event loop, since `subscribe` should also be called on next tick
-  process.nextTick(function() {
+  setImmediate(() => {
     t.ok(q._provider.subscribe.called, 'Provider `subscribe` not called.');
     t.notOk(q._provider.subscribe.calledTwice, 'Provider `subscribe` called more than once.');
     t.end();
   });
 });
 
-tap.test('Calls provider `unsubscribe` method once when last listener is removed', function(t) {
+tap.test('Calls provider `unsubscribe` method once when last listener is removed', (t) => {
   const q = new Queue({ provider: 'amqp' });
   q._provider.subscribe = sinon.stub();
   q._provider.unsubscribe = sinon.stub();
-  q.on('message', function() { });
-  q.on('message', function() { });
+  q.on('message', noop => noop);
+  q.on('message', noop => noop);
 
   // Defer this until next event loop, since `subscribe` should also be called on next tick
-  process.nextTick(function() {
+  setImmediate(() => {
     q.removeAllListeners('message');
     t.ok(q._provider.unsubscribe.called, 'Provider `unsubscribe` not called.');
     t.notOk(q._provider.unsubscribe.calledTwice, 'Provider `unsubscribe` called more than once.');
@@ -111,22 +111,22 @@ tap.test('Calls provider `unsubscribe` method once when last listener is removed
   });
 });
 
-tap.test('Does not unsubscribe from provider if "removeListener" event name is not "message"', function(t) {
+tap.test('Does not unsubscribe from provider if "removeListener" event name is not "message"', (t) => {
   const q = new Queue({ provider: 'amqp' });
   q._provider.subscribe = sinon.stub();
   q._provider.unsubscribe = sinon.stub();
-  q.on('message', function() { });
-  q.on('foobar', function() { });
+  q.on('message', noop => noop);
+  q.on('foobar', noop => noop);
 
   // Defer this until next event loop, since `subscribe` should also be called on next tick
-  process.nextTick(function() {
+  setImmediate(() => {
     q.removeAllListeners('foobar');
     t.notOk(q._provider.unsubscribe.called, 'Provider `unsubscribe` should not have been called.');
     t.end();
   });
 });
 
-tap.test('Forwards message publishing to the provider', function(t) {
+tap.test('Forwards message publishing to the provider', (t) => {
   const q = new Queue({ provider: 'amqp' });
   const expectedMessage = 'a value';
   q._provider.publish = sinon.stub();
@@ -136,7 +136,7 @@ tap.test('Forwards message publishing to the provider', function(t) {
   t.end();
 });
 
-tap.test('Forwards message ack to the provider', function(t) {
+tap.test('Forwards message ack to the provider', (t) => {
   const q = new Queue({ provider: 'amqp' });
   const expectedMessageId = 'message-id';
   q._provider.ack = sinon.stub();
@@ -146,7 +146,7 @@ tap.test('Forwards message ack to the provider', function(t) {
   t.end();
 });
 
-tap.test('Forwards queue close to the provider', function(t) {
+tap.test('Forwards queue close to the provider', (t) => {
   const q = new Queue({ provider: 'amqp' });
   q._provider.close = sinon.stub();
   q.close();


### PR DESCRIPTION
Main focus of this PR is to convert closures to arrow functions.  There are three other changes that slipped in:

1. Converting `process.nextTick` to `setImmediate`.  There's a subtle different between the two, and `setImmediate` is really the desired behavior here.
2. Removed the `self` variables.  Completely unneeded now that arrow functions are used.
3. Fix a bug with the ZMQ provider where the queue name / topic was being prepended and then stripped out on receive.  This is not the correct approach.  This is now fully corrected.