### PR TITLE
Add support for optional SQS arguments

### DIFF
--- a/lib/providers/sqs.js
+++ b/lib/providers/sqs.js
@@ -29,7 +29,7 @@ class SqsProvider {
     setImmediate(() => this.initProvider());
   }
 
-  publish(message) {
+  publish(message, paramArg) {
     let messageStr = message;
     if (message instanceof Buffer) {
       messageStr = message.toString('base64');
@@ -38,9 +38,9 @@ class SqsProvider {
     }
 
     if (this.emitter.isReady) {
-      setImmediate(() => this.sendMessage(messageStr));
+      setImmediate(() => this.sendMessage(messageStr, paramArg));
     } else {
-      this.emitter.once('ready', () => this.sendMessage(messageStr));
+      this.emitter.once('ready', () => this.sendMessage(messageStr, paramArg));
     }
   }
 
@@ -164,11 +164,15 @@ class SqsProvider {
     }
   }
 
-  sendMessage(message) {
-    const param = {
+  sendMessage(message, paramArg) {
+    let param = {
       QueueUrl: this.queueUrl,
       MessageBody: message,
     };
+
+    if (paramArg) {
+      param = Object.assign({}, param, paramArg); // merge the argument list given to AWS if any is provided as an argument
+    }
 
     this.sqs.sendMessage(param, (err) => {
       if (err) {

--- a/lib/providers/sqs.js
+++ b/lib/providers/sqs.js
@@ -171,7 +171,8 @@ class SqsProvider {
     };
 
     if (paramArg) {
-      param = Object.assign({}, param, paramArg); // merge the argument list given to AWS if any is provided as an argument
+      param = Object.assign({}, param, paramArg);
+      // merge the argument list given to AWS if any is provided as an argument
     }
 
     this.sqs.sendMessage(param, (err) => {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -28,8 +28,8 @@ class Queue extends EventEmitter {
     this.setupSubscriptionHandling();
   }
 
-  publish(message) {
-    this.provider.publish(message);
+  publish(message, paramArg) {
+    this.provider.publish(message, paramArg);
   }
 
   ack(messageId) {

--- a/test/lib/providers/sqs.js
+++ b/test/lib/providers/sqs.js
@@ -252,6 +252,30 @@ tap.test('Calls publish function with string message', (t) => {
   });
 });
 
+tap.test('Calls publish function with string message and dictionary of options', (t) => {
+  const providerOptions = { queueName: 'queue' };
+  const message = 'test message';
+  const emitter = new EventEmitter();
+  const provider = createProvider(emitter, providerOptions);
+
+  provider.publish(message, { test: 'test' });
+
+  emitter.once('ready', () => {
+    // Defer this test to wait for all deferred methods in provider to run
+    setImmediate(() => {
+      const expectedParams = {
+        QueueUrl: provider.queueUrl,
+        MessageBody: message,
+        test: 'test',
+      };
+
+      t.ok(provider.sqs.sendMessage.called);
+      t.same(provider.sqs.sendMessage.getCall(0).args[0], expectedParams);
+      t.end();
+    });
+  });
+});
+
 tap.test('Calls publish function with JSON string', (t) => {
   const providerOptions = { queueName: 'queue' };
   const message = { test: 'obj', foo: 'bar' };


### PR DESCRIPTION
FIFO queues are required to have a MessageGroupID, and a DeduplicationID if the queue is not set to have content-based deduplication. As we cannot provide our own arguments to SQS through the library, this makes it impossible to write to FIFO queues. This PR allows one to submit a dictionary of key-value pairs which will be sent as arguments, directly to the SQS library.