### PR TITLE
v0.4.0 version bump including documentation update and variable rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+# v0.4.0 (2017-12-03)
+New features:
+- Add new options arg to `publish` function
+
 # v0.3.0 (2017-02-27)
 No known breaking changes.  We're now complying with semver from here forward.
 

--- a/README.md
+++ b/README.md
@@ -142,13 +142,19 @@ queue.on('error', function(error) {
 });
 ```
 
-#### .publish(message)
+#### .publish(message [, options])
 Publishes a message to the queue. `message` can be a JavaScript object, a string, or a Buffer.
+
+The optional `options` argument passes provider-specific options to the related publishing
+functionality of the queue provider used.
 
 ```javascript
 queue.publish('This is a string message');
 queue.publish({ foo: 'bar', baz: 3 });
 queue.publish(new Buffer([1, 2, 3, 4, 5, 6, 7, 8]));
+
+// Example with SQS publish options
+queue.publish('My message', { 'MessageDeduplicationId': 'abcdef123456' });
 ```
 
 #### .ack(messageId)

--- a/lib/providers/sqs.js
+++ b/lib/providers/sqs.js
@@ -29,7 +29,7 @@ class SqsProvider {
     setImmediate(() => this.initProvider());
   }
 
-  publish(message, paramArg) {
+  publish(message, options) {
     let messageStr = message;
     if (message instanceof Buffer) {
       messageStr = message.toString('base64');
@@ -38,9 +38,9 @@ class SqsProvider {
     }
 
     if (this.emitter.isReady) {
-      setImmediate(() => this.sendMessage(messageStr, paramArg));
+      setImmediate(() => this.sendMessage(messageStr, options));
     } else {
-      this.emitter.once('ready', () => this.sendMessage(messageStr, paramArg));
+      this.emitter.once('ready', () => this.sendMessage(messageStr, options));
     }
   }
 
@@ -164,14 +164,14 @@ class SqsProvider {
     }
   }
 
-  sendMessage(message, paramArg) {
+  sendMessage(message, options) {
     let param = {
       QueueUrl: this.queueUrl,
       MessageBody: message,
     };
 
-    if (paramArg) {
-      param = Object.assign({}, param, paramArg);
+    if (options) {
+      param = Object.assign({}, param, options);
       // merge the argument list given to AWS if any is provided as an argument
     }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -28,8 +28,8 @@ class Queue extends EventEmitter {
     this.setupSubscriptionHandling();
   }
 
-  publish(message, paramArg) {
-    this.provider.publish(message, paramArg);
+  publish(message, options) {
+    this.provider.publish(message, options);
   }
 
   ack(messageId) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-mq",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Abstracted message queue client for node.js supporting multiple message queue providers.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updates the version for the `publish` method options and includes CHANGELOG and README updates.  Also change variable name to be more consistent with the rest of the library api.